### PR TITLE
all: replace module name to containerd instead of alibaba

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          path: src/github.com/alibaba/accelerated-container-image
+          path: src/github.com/containerd/accelerated-container-image
 
       - name: set env
         shell: bash
@@ -33,7 +33,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.42.0
-          working-directory: src/github.com/alibaba/accelerated-container-image
+          working-directory: src/github.com/containerd/accelerated-container-image
           args: --timeout=5m
 
 
@@ -49,7 +49,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          path: src/github.com/alibaba/accelerated-container-image
+          path: src/github.com/containerd/accelerated-container-image
           fetch-depth: 100
 
       - name: set env
@@ -71,7 +71,7 @@ jobs:
 
       - name: DCO checker
         shell: bash
-        working-directory: src/github.com/alibaba/accelerated-container-image
+        working-directory: src/github.com/containerd/accelerated-container-image
         env:
           GITHUB_COMMIT_URL: ${{ github.event.pull_request.commits_url }}
           DCO_VERBOSITY: "-v"
@@ -92,7 +92,7 @@ jobs:
 
       - name: validate file headers
         shell: bash
-        working-directory: src/github.com/alibaba/accelerated-container-image
+        working-directory: src/github.com/containerd/accelerated-container-image
         run: |
           set -eu -o pipefail
           echo "::group:: file headers"
@@ -110,7 +110,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          path: src/github.com/alibaba/accelerated-container-image
+          path: src/github.com/containerd/accelerated-container-image
           fetch-depth: 100
 
       - name: install Go
@@ -125,6 +125,6 @@ jobs:
           echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
       - name: unit test
-        working-directory: src/github.com/alibaba/accelerated-container-image
+        working-directory: src/github.com/containerd/accelerated-container-image
         run: |
           sudo GO_TESTFLAGS=-v make test

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The key features are:
 
 ## Components
 
-* [overlaybd](https://github.com/alibaba/overlaybd)
+* [overlaybd](https://github.com/containerd/overlaybd)
 
     Overlaybd provides a merged view of block-based layer sequence as an virtual block device in user space.
 
@@ -39,7 +39,7 @@ The key features are:
 
 ## Getting Started
 
-* See how to setup overlaybd backstore at [README](https://github.com/alibaba/overlaybd).
+* See how to setup overlaybd backstore at [README](https://github.com/containerd/overlaybd).
 
 * See how to build snaphshotter and ctr plugin components at [BUILDING](docs/BUILDING.md).
 

--- a/cmd/overlaybd-snapshotter/main.go
+++ b/cmd/overlaybd-snapshotter/main.go
@@ -27,7 +27,7 @@ import (
 	"runtime"
 	"strings"
 
-	overlaybd "github.com/alibaba/accelerated-container-image/pkg/snapshot"
+	overlaybd "github.com/containerd/accelerated-container-image/pkg/snapshot"
 
 	snapshotsapi "github.com/containerd/containerd/api/services/snapshots/v1"
 	"github.com/containerd/containerd/contrib/snapshotservice"

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -21,7 +21,7 @@ This doc includes:
 You need git to checkout the source code and compile:
 
 ```bash
-git clone https://github.com/alibaba/accelerated-container-image.git
+git clone https://github.com/containerd/accelerated-container-image.git
 cd accelerated-container-image
 make
 ```

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-Before checkout the examples, make sure that you have built or installed the components described in [overlaybd](https://github.com/alibaba/overlaybd/blob/main/README.md) and [BUILDING](BUILDING.md).
+Before checkout the examples, make sure that you have built or installed the components described in [overlaybd](https://github.com/containerd/overlaybd/blob/main/README.md) and [BUILDING](BUILDING.md).
 
 This doc includes:
 
@@ -17,7 +17,7 @@ This doc includes:
 
 Check whether the `overlaybd-tcmu` is running.
 
-For any problems, please checkout [overlaybd](https://github.com/alibaba/overlaybd).
+For any problems, please checkout [overlaybd](https://github.com/containerd/overlaybd).
 
 ### Proxy overlaybd snapshotter
 

--- a/docs/EXAMPLES_CRI.md
+++ b/docs/EXAMPLES_CRI.md
@@ -2,7 +2,7 @@
 
 ## Check Components
 
-Before checkout the cri examples, make sure that you have built or installed the components described in [overlaybd](https://github.com/alibaba/overlaybd/README.md) and [BUILDING](BUILDING.md).
+Before checkout the cri examples, make sure that you have built or installed the components described in [overlaybd](https://github.com/containerd/overlaybd/README.md) and [BUILDING](BUILDING.md).
 You can check your overlaybd components as described in [EXAMPLES](EXAMPLES.md#check-components).
 
 ## Containerd config

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -37,4 +37,4 @@ time ./setup-wordpress.sh registry.hub.docker.com/overlaybd/wordpress:5.7.0
 
 Conclusion: Overlaybd format outperforms OCI tar format at startup speed.
 
-Note: The [prefetch](https://github.com/alibaba/accelerated-container-image/blob/main/docs/trace-prefetch.md) feature is enabled.
+Note: The [prefetch](https://github.com/containerd/accelerated-container-image/blob/main/docs/trace-prefetch.md) feature is enabled.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/alibaba/accelerated-container-image
+module github.com/containerd/accelerated-container-image
 
 go 1.15
 


### PR DESCRIPTION
Replace module name to `containerd` instead of `alibaba`.