### PR TITLE
snapshotter: fix mkfs error for ext4 by add '-F' option

### DIFF
--- a/pkg/snapshot/iscsi.go
+++ b/pkg/snapshot/iscsi.go
@@ -286,7 +286,7 @@ func (o *snapshotter) attachAndMountBlockDevice(ctx context.Context, snID string
 				} else {
 					switch fstype {
 					case "ext4":
-						args = append(args, "-O", "^has_journal,sparse_super,flex_bg", "-G", "1", "-E", "discard")
+						args = append(args, "-O", "^has_journal,sparse_super,flex_bg", "-G", "1", "-E", "discard", "-F")
 					case "xfs":
 						args = append(args, "-f", "-l", "size=4m", "-m", "crc=0")
 					case "f2fs":


### PR DESCRIPTION
Without the option, mkfs will fail with error "failed to mkfs for dev
/dev/sdm: mke2fs 1.42.9 (28-Dec-2013)\n/dev/sdm is entire device,
not just one partition! \nProceed anyway? (y,n) : exit status 1"

Signed-off-by: Wang Xingxing <stellarwxx@gmail.com>