### PR TITLE
snapshotter: clean snapshot path when bbolt rollback in createMountPoint

### DIFF
--- a/pkg/snapshot/overlay.go
+++ b/pkg/snapshot/overlay.go
@@ -339,7 +339,8 @@ func (o *snapshotter) createMountPoint(ctx context.Context, kind snapshots.Kind,
 		return nil, err
 	}
 	defer func() {
-		if retErr != nil && !errdefs.IsAlreadyExists(retErr) {
+		// the transaction rollback makes created snapshot invalid, just clean it.
+		if retErr != nil && rollback == true {
 			if rerr := os.RemoveAll(o.snPath(id)); rerr != nil {
 				log.G(ctx).WithError(rerr).Warn("failed to cleanup")
 			}


### PR DESCRIPTION
Fixes: #105

Signed-off-by: Wang Xingxing <stellarwxx@gmail.com>