### PR TITLE
BUG FIX: ignore overlaybd writable label for normal images

### DIFF
--- a/pkg/snapshot/storage.go
+++ b/pkg/snapshot/storage.go
@@ -87,7 +87,7 @@ func (o *snapshotter) unmountAndDetachBlockDevice(ctx context.Context, snID stri
 	if err != nil {
 		return errors.Wrapf(err, "can't get snapshot info.")
 	}
-	writeType := o.getWritableType(ctx, info)
+	writeType := o.getWritableType(ctx, snID, info)
 
 	if writeType != rwDev {
 		mountPoint := o.overlaybdMountpoint(snID)


### PR DESCRIPTION
overlaybd snapshotter should check the image type when the label
'containerd.io/snapshot/overlaybd.writable' has been set.

this value should be ignored for normal images. #123

Signed-off-by: Yifan Yuan <tuji.yyf@alibaba-inc.com>