### PR TITLE
Remove io/ioutil package dependency

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,6 @@
 linters:
   enable:
+    - depguard
     - structcheck
     - varcheck
     - staticcheck
@@ -13,3 +14,12 @@ linters:
     - misspell
   disable:
     - errcheck
+
+linters-settings:
+  depguard:
+    list-type: denylist
+    include-go-root: true
+    packages:
+      # use "io" or "os" instead
+      # https://go.dev/doc/go1.16#ioutil
+      - io/ioutil

--- a/cmd/convertor/main.go
+++ b/cmd/convertor/main.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -223,7 +222,7 @@ func convert() error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to fetch manifest")
 	}
-	buf, err := ioutil.ReadAll(rc)
+	buf, err := io.ReadAll(rc)
 	if err != nil {
 		return errors.Wrapf(err, "failed to fetch manifest")
 	}
@@ -239,7 +238,7 @@ func convert() error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to fetch config")
 	}
-	buf, err = ioutil.ReadAll(rc)
+	buf, err = io.ReadAll(rc)
 	if err != nil {
 		return errors.Wrapf(err, "failed to fetch config")
 	}

--- a/cmd/overlaybd-snapshotter/main.go
+++ b/cmd/overlaybd-snapshotter/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/signal"
@@ -49,7 +48,7 @@ type pluginConfig struct {
 var pconfig pluginConfig
 
 func parseConfig(fpath string) error {
-	data, err := ioutil.ReadFile(fpath)
+	data, err := os.ReadFile(fpath)
 	if err != nil {
 		return errors.Wrapf(err, "failed to read plugin config from %s", fpath)
 	}

--- a/pkg/convertor/convertor.go
+++ b/pkg/convertor/convertor.go
@@ -27,7 +27,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -601,7 +600,7 @@ func (c *overlaybdConvertor) applyOCIV1LayerInZfile(
 	}
 
 	// Read any trailing data
-	if _, err := io.Copy(ioutil.Discard, rc); err != nil {
+	if _, err := io.Copy(io.Discard, rc); err != nil {
 		return emptyString, err
 	}
 

--- a/pkg/snapshot/overlay.go
+++ b/pkg/snapshot/overlay.go
@@ -19,7 +19,6 @@ package snapshot
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -768,7 +767,7 @@ func (o *snapshotter) Walk(ctx context.Context, fn snapshots.WalkFunc, fs ...str
 }
 
 func (o *snapshotter) prepareDirectory(ctx context.Context, snapshotDir string, kind snapshots.Kind) (string, error) {
-	td, err := ioutil.TempDir(snapshotDir, "new-")
+	td, err := os.MkdirTemp(snapshotDir, "new-")
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create temp dir")
 	}
@@ -820,7 +819,7 @@ func (o *snapshotter) basedOnBlockDeviceMount(ctx context.Context, s storage.Sna
 		}, nil
 	}
 	if writeType == rwDev {
-		devName, err := ioutil.ReadFile(o.overlaybdBackstoreMarkFile(s.ID))
+		devName, err := os.ReadFile(o.overlaybdBackstoreMarkFile(s.ID))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Package io/ioutil has been marked deprecated in Go 1.16.

Signed-off-by: Austin Vazquez <macedonv@amazon.com>