### PR TITLE
support auto cleanup overlaybd

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -57,11 +57,23 @@ The config file is `/etc/overlaybd-snapshotter/config.json`. Please create the f
 
 ```json
 {
-    "root": "/var/lib/overlaybd/",
-    "address": "/run/overlaybd-snapshotter/overlaybd.sock"
+    "root": "/var/lib/containerd/io.containerd.snapshotter.v1.overlaybd",
+    "address": "/run/overlaybd-snapshotter/overlaybd.sock",
+    "verbose": "info",
+    "mode": "overlayfs",
+    "logReportCaller": false,
+    "autoRemoveDev": false
 }
 ```
-`root` is the root directory to store snapshots, `address` is the socket address used to connect withcontainerd.
+| Field | Description |
+| ----- | ----------- |
+| `root` | the root directory to store snapshots |
+| `address` | the socket address used to connect withcontainerd. |
+| `verbose` | log level, `info` or `debug` |
+| `mode` | rootfs mode about wether to use native writable layer. See [Native Support for Writable](docs/WRITABLE.md) for detail. |
+| `logReportCaller` | enable/disable the calling method |
+| `autoRemoveDev` | enable/disable auto clean-up overlaybd device after container removed |
+
 
 #### Start service
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -60,7 +60,7 @@ The config file is `/etc/overlaybd-snapshotter/config.json`. Please create the f
     "root": "/var/lib/containerd/io.containerd.snapshotter.v1.overlaybd",
     "address": "/run/overlaybd-snapshotter/overlaybd.sock",
     "verbose": "info",
-    "mode": "overlayfs",
+    "rwMode": "overlayfs",
     "logReportCaller": false,
     "autoRemoveDev": false
 }
@@ -70,7 +70,7 @@ The config file is `/etc/overlaybd-snapshotter/config.json`. Please create the f
 | `root` | the root directory to store snapshots |
 | `address` | the socket address used to connect withcontainerd. |
 | `verbose` | log level, `info` or `debug` |
-| `mode` | rootfs mode about wether to use native writable layer. See [Native Support for Writable](docs/WRITABLE.md) for detail. |
+| `rwMode` | rootfs mode about wether to use native writable layer. See [Native Support for Writable](docs/WRITABLE.md) for detail. |
 | `logReportCaller` | enable/disable the calling method |
 | `autoRemoveDev` | enable/disable auto clean-up overlaybd device after container removed |
 

--- a/pkg/snapshot/overlay.go
+++ b/pkg/snapshot/overlay.go
@@ -570,7 +570,7 @@ func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...s
 // View returns a readonly view on parent snapshotter.
 func (o *snapshotter) View(ctx context.Context, key, parent string, opts ...snapshots.Opt) (_ []mount.Mount, retErr error) {
 	log.G(ctx).Debugf("View (key: %s, parent: %s)", key, parent)
-
+	defer log.G(ctx).Debugf("return View (key: %s, parent: %s)", key, parent)
 	return o.createMountPoint(ctx, snapshots.KindView, key, parent, opts...)
 }
 
@@ -966,6 +966,9 @@ func (o *snapshotter) normalOverlayMount(s storage.Snapshot) []mount.Mount {
 			fmt.Sprintf("workdir=%s", o.workPath(s.ID)),
 			fmt.Sprintf("upperdir=%s", o.upperPath(s.ID)),
 		)
+		// if o.metacopyOption != "" {
+		// 	options = append(options, o.metacopyOption)
+		// }
 	} else if len(s.ParentIDs) == 1 {
 		return []mount.Mount{
 			{

--- a/pkg/snapshot/overlay_test.go
+++ b/pkg/snapshot/overlay_test.go
@@ -28,6 +28,7 @@ import (
 func newSnapshotterWithOpts(opts ...Opt) testsuite.SnapshotterFunc {
 	return func(ctx context.Context, root string) (snapshots.Snapshotter, func() error, error) {
 		cfg := DefaultBootConfig()
+		cfg.Root = root
 		snapshotter, err := NewSnapshotter(cfg, opts...)
 		if err != nil {
 			return nil, nil, err

--- a/pkg/snapshot/overlay_test.go
+++ b/pkg/snapshot/overlay_test.go
@@ -27,7 +27,8 @@ import (
 
 func newSnapshotterWithOpts(opts ...Opt) testsuite.SnapshotterFunc {
 	return func(ctx context.Context, root string) (snapshots.Snapshotter, func() error, error) {
-		snapshotter, err := NewSnapshotter(root, "fs", opts...)
+		cfg := DefaultBootConfig()
+		snapshotter, err := NewSnapshotter(cfg, opts...)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/snapshot/storage.go
+++ b/pkg/snapshot/storage.go
@@ -551,6 +551,8 @@ func (o *snapshotter) constructOverlayBDSpec(ctx context.Context, key string, wr
 			Data:  o.overlaybdWritableDataPath(id),
 		}
 	}
+	configBuffer, _ := json.MarshalIndent(configJSON, "", "  ")
+	log.G(ctx).Infoln(string(configBuffer))
 	return o.atomicWriteOverlaybdTargetConfig(id, &configJSON)
 }
 

--- a/script/config.json
+++ b/script/config.json
@@ -1,4 +1,8 @@
 {
     "root": "/var/lib/containerd/io.containerd.snapshotter.v1.overlaybd",
-    "address": "/run/overlaybd-snapshotter/overlaybd.sock"
+    "address": "/run/overlaybd-snapshotter/overlaybd.sock",
+    "verbose": "info",
+    "mode": "overlayfs",
+    "logReportCaller": false,
+    "autoRemoveDev": false
 }

--- a/script/config.json
+++ b/script/config.json
@@ -2,7 +2,7 @@
     "root": "/var/lib/containerd/io.containerd.snapshotter.v1.overlaybd",
     "address": "/run/overlaybd-snapshotter/overlaybd.sock",
     "verbose": "info",
-    "mode": "overlayfs",
+    "rwMode": "overlayfs",
     "logReportCaller": false,
     "autoRemoveDev": false
 }


### PR DESCRIPTION
1. support auto cleanup overlaybd after container removed by configoption 'autoRemoveDev'

2. rename mode tag of rootfs as 'overlayfs/dir/dev'

Signed-off-by: Yifan Yuan <tuji.yyf@alibaba-inc.com>