### PR TITLE
go.mod: retract v0.5.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,3 +62,6 @@ require (
 	google.golang.org/protobuf v1.27.1 // indirect
 	gotest.tools/v3 v3.0.3 // indirect
 )
+
+// v0.5.2 was retagged: 71d70d4e738679154f62e2869e94784558cb9b36 -> fd022b910830015d8665a7b497f47bba1f90dd18
+retract v0.5.2


### PR DESCRIPTION
v0.5.2 was retagged:
https://github.com/containerd/accelerated-container-image/compare/71d70d4e738679154f62e2869e94784558cb9b36...fd022b910830015d8665a7b497f47bba1f90dd18

https://github.com/containerd/nerdctl/issues/1627#issuecomment-1343751786


Description about the `retract` directive: https://go.dev/ref/mod#go-mod-file-retract
