### PR TITLE
support fastoci build and rpull

### DIFF
--- a/cmd/convertor/builder/builder.go
+++ b/cmd/convertor/builder/builder.go
@@ -1,0 +1,180 @@
+/*
+   Copyright The Accelerated Container Image Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package builder
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	"github.com/containerd/containerd/remotes/docker"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+type Builder interface {
+	Build(ctx context.Context) error
+}
+
+type BuilderOptions struct {
+	Ref       string
+	TargetRef string
+	Auth      string
+	PlainHTTP bool
+	WorkDir   string
+	OCI       bool
+	Engine    BuilderEngineType
+}
+
+type overlaybdBuilder struct {
+	layers int
+	engine builderEngine
+}
+
+func NewOverlayBDBuilder(ctx context.Context, opt BuilderOptions) (Builder, error) {
+	resolver := docker.NewResolver(docker.ResolverOptions{
+		Credentials: func(s string) (string, string, error) {
+			if opt.Auth == "" {
+				return "", "", nil
+			}
+			authSplit := strings.Split(opt.Auth, ":")
+			return authSplit[0], authSplit[1], nil
+		},
+		PlainHTTP: opt.PlainHTTP,
+	})
+	engineBase, err := getBuilderEngineBase(ctx, resolver, opt.Ref, opt.TargetRef)
+	if err != nil {
+		return nil, err
+	}
+	engineBase.workDir = opt.WorkDir
+	engineBase.oci = opt.OCI
+	var engine builderEngine
+	switch opt.Engine {
+	case BuilderEngineTypeOverlayBD:
+		engine = NewOverlayBDBuilderEngine(engineBase)
+	case BuilderEngineTypeFastOCI:
+		engine = NewFastOCIBuilderEngine(engineBase)
+	}
+	return &overlaybdBuilder{
+		layers: len(engineBase.manifest.Layers),
+		engine: engine,
+	}, nil
+}
+
+func (b *overlaybdBuilder) Build(ctx context.Context) error {
+	defer b.engine.Cleanup()
+	downloaded := make([]chan error, b.layers)
+	converted := make([]chan error, b.layers)
+	var uploaded sync.WaitGroup
+
+	errCh := make(chan error)
+	defer close(errCh)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// collect error and kill all builder goroutines
+	var retErr error
+	retErr = nil
+	go func() {
+		select {
+		case <-ctx.Done():
+		case retErr = <-errCh:
+		}
+		if retErr != nil {
+			cancel()
+		}
+	}()
+
+	for i := 0; i < b.layers; i++ {
+		downloaded[i] = make(chan error)
+		converted[i] = make(chan error)
+
+		// download goroutine
+		go func(idx int) {
+			defer close(downloaded[idx])
+			if err := b.engine.DownloadLayer(ctx, idx); err != nil {
+				sendToChannel(ctx, errCh, errors.Wrapf(err, "failed to download layer %d", idx))
+				return
+			}
+			logrus.Infof("downloaded layer %d", idx)
+			sendToChannel(ctx, downloaded[idx], nil)
+		}(i)
+
+		// convert goroutine
+		go func(idx int) {
+			defer close(converted[idx])
+			if waitForChannel(ctx, downloaded[idx]); ctx.Err() != nil {
+				return
+			}
+			if idx > 0 {
+				if waitForChannel(ctx, converted[idx-1]); ctx.Err() != nil {
+					return
+				}
+			}
+			if err := b.engine.BuildLayer(ctx, idx); err != nil {
+				sendToChannel(ctx, errCh, errors.Wrapf(err, "failed to convert layer %d", idx))
+				return
+			}
+			logrus.Infof("layer %d converted", idx)
+			// send to upload(idx) and convert(idx+1) once each
+			sendToChannel(ctx, converted[idx], nil)
+			if idx+1 < b.layers {
+				sendToChannel(ctx, converted[idx], nil)
+			}
+		}(i)
+
+		// upload goroutine
+		uploaded.Add(1)
+		go func(idx int) {
+			defer uploaded.Done()
+			if waitForChannel(ctx, converted[idx]); ctx.Err() != nil {
+				return
+			}
+			if err := b.engine.UploadLayer(ctx, idx); err != nil {
+				sendToChannel(ctx, errCh, errors.Wrapf(err, "failed to upload layer %d", idx))
+				return
+			}
+			logrus.Infof("layer %d uploaded", idx)
+		}(i)
+	}
+	uploaded.Wait()
+	if retErr != nil {
+		return retErr
+	}
+
+	if err := b.engine.UploadImage(ctx); err != nil {
+		return errors.Wrap(err, "failed to upload manifest or config")
+	}
+	logrus.Info("convert finished")
+	return nil
+}
+
+// block until ctx.Done() or sent
+func sendToChannel(ctx context.Context, ch chan<- error, value error) {
+	select {
+	case <-ctx.Done():
+	case ch <- value:
+	}
+}
+
+// block until ctx.Done() or received
+func waitForChannel(ctx context.Context, ch <-chan error) {
+	select {
+	case <-ctx.Done():
+	case <-ch:
+	}
+}

--- a/cmd/convertor/builder/builder_engine.go
+++ b/cmd/convertor/builder/builder_engine.go
@@ -1,0 +1,169 @@
+/*
+   Copyright The Accelerated Container Image Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package builder
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/containerd/containerd/archive/compression"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/remotes"
+	"github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+type BuilderEngineType int
+
+const (
+	BuilderEngineTypeOverlayBD BuilderEngineType = iota
+	BuilderEngineTypeFastOCI
+)
+
+type builderEngine interface {
+	DownloadLayer(ctx context.Context, idx int) error
+
+	// build layer archive, maybe tgz or zfile
+	BuildLayer(ctx context.Context, idx int) error
+
+	UploadLayer(ctx context.Context, idx int) error
+
+	// UploadImage upload new manifest and config
+	UploadImage(ctx context.Context) error
+
+	// cleanup remove workdir
+	Cleanup()
+}
+
+type builderEngineBase struct {
+	fetcher  remotes.Fetcher
+	pusher   remotes.Pusher
+	manifest specs.Manifest
+	config   specs.Image
+	workDir  string
+	oci      bool
+}
+
+func (e *builderEngineBase) isGzipLayer(ctx context.Context, idx int) (bool, error) {
+	rc, err := e.fetcher.Fetch(ctx, e.manifest.Layers[idx])
+	if err != nil {
+		return false, errors.Wrapf(err, "isGzipLayer: failed to open layer %d", idx)
+	}
+	drc, err := compression.DecompressStream(rc)
+	if err != nil {
+		return false, errors.Wrapf(err, "isGzipLayer: failed to open decompress stream for layer %d", idx)
+	}
+	compress := drc.GetCompression()
+	switch compress {
+	case compression.Uncompressed:
+		return false, nil
+	case compression.Gzip:
+		return true, nil
+	default:
+		return false, fmt.Errorf("isGzipLayer: unsupported layer format with compression %s", compress.Extension())
+	}
+}
+
+func (e *builderEngineBase) mediaTypeManifest() string {
+	if e.oci {
+		return specs.MediaTypeImageManifest
+	} else {
+		return images.MediaTypeDockerSchema2Manifest
+	}
+}
+
+func (e *builderEngineBase) mediaTypeConfig() string {
+	if e.oci {
+		return specs.MediaTypeImageConfig
+	} else {
+		return images.MediaTypeDockerSchema2Config
+	}
+}
+
+func (e *builderEngineBase) mediaTypeImageLayerGzip() string {
+	if e.oci {
+		return specs.MediaTypeImageLayerGzip
+	} else {
+		return images.MediaTypeDockerSchema2LayerGzip
+	}
+}
+
+func (e *builderEngineBase) mediaTypeImageLayer() string {
+	if e.oci {
+		return specs.MediaTypeImageLayer
+	} else {
+		return images.MediaTypeDockerSchema2Layer
+	}
+}
+
+func (e *builderEngineBase) uploadManifestAndConfig(ctx context.Context) error {
+	cbuf, err := json.Marshal(e.config)
+	if err != nil {
+		return err
+	}
+	e.manifest.Config = specs.Descriptor{
+		MediaType: e.mediaTypeConfig(),
+		Digest:    digest.FromBytes(cbuf),
+		Size:      (int64)(len(cbuf)),
+	}
+	if err = uploadBytes(ctx, e.pusher, e.manifest.Config, cbuf); err != nil {
+		return errors.Wrapf(err, "failed to upload config")
+	}
+
+	e.manifest.MediaType = e.mediaTypeManifest()
+	cbuf, err = json.Marshal(e.manifest)
+	if err != nil {
+		return err
+	}
+	manifestDesc := specs.Descriptor{
+		MediaType: e.mediaTypeManifest(),
+		Digest:    digest.FromBytes(cbuf),
+		Size:      (int64)(len(cbuf)),
+	}
+
+	if err = uploadBytes(ctx, e.pusher, manifestDesc, cbuf); err != nil {
+		return errors.Wrapf(err, "failed to upload manifest")
+	}
+	return nil
+}
+
+func getBuilderEngineBase(ctx context.Context, resolver remotes.Resolver, ref, targetRef string) (*builderEngineBase, error) {
+	_, desc, err := resolver.Resolve(ctx, ref)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to resolve reference %q", ref)
+	}
+	fetcher, err := resolver.Fetcher(ctx, ref)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get fetcher for %q", ref)
+	}
+	pusher, err := resolver.Pusher(ctx, targetRef)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get pusher for %q", targetRef)
+	}
+	manifest, config, err := fetchManifestAndConfig(ctx, fetcher, desc)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to fetch manifest and config")
+	}
+	return &builderEngineBase{
+		fetcher:  fetcher,
+		pusher:   pusher,
+		manifest: manifest,
+		config:   config,
+	}, nil
+}

--- a/cmd/convertor/builder/fastoci_builder.go
+++ b/cmd/convertor/builder/fastoci_builder.go
@@ -24,6 +24,7 @@ import (
 	"path"
 	"path/filepath"
 
+	"github.com/containerd/accelerated-container-image/pkg/label"
 	"github.com/containerd/accelerated-container-image/pkg/snapshot"
 	"github.com/containerd/containerd/archive/compression"
 	"github.com/containerd/containerd/images"
@@ -33,13 +34,6 @@ import (
 )
 
 const (
-	// labelKeyFastOCIImageRef is the index annotation key for image layer digest
-	labelKeyFastOCIDigest = "containerd.io/snapshot/overlaybd/fastoci/target-digest"
-
-	// labelKeyFastOCIMediaType is the index annotation key for image layer media type,
-	// indicate if image layer is in gzip format or not
-	labelKeyFastOCIMediaType = "containerd.io/snapshot/overlaybd/fastoci/target-media-type"
-
 	// index of OCI layers (gzip)
 	gzipMetaFile = "gzip.meta"
 
@@ -139,9 +133,9 @@ func (e *fastOCIBuilderEngine) UploadLayer(ctx context.Context, idx int) error {
 	}
 	desc.MediaType = e.mediaTypeImageLayerGzip()
 	desc.Annotations = map[string]string{
-		labelKeyOverlayBDBlobDigest: desc.Digest.String(),
-		labelKeyOverlayBDBlobSize:   fmt.Sprintf("%d", desc.Size),
-		labelKeyFastOCIDigest:       e.manifest.Layers[idx].Digest.String(),
+		label.OverlayBDBlobDigest: desc.Digest.String(),
+		label.OverlayBDBlobSize:   fmt.Sprintf("%d", desc.Size),
+		label.FastOCIDigest:       e.manifest.Layers[idx].Digest.String(),
 	}
 	targetMediaType := ""
 	if images.IsDockerType(e.manifest.Layers[idx].MediaType) {
@@ -157,7 +151,7 @@ func (e *fastOCIBuilderEngine) UploadLayer(ctx context.Context, idx int) error {
 			targetMediaType = specs.MediaTypeImageLayer
 		}
 	}
-	desc.Annotations[labelKeyFastOCIMediaType] = targetMediaType
+	desc.Annotations[label.FastOCIMediaType] = targetMediaType
 	if err := uploadBlob(ctx, e.pusher, path.Join(layerDir, fociLayerTar), desc); err != nil {
 		return errors.Wrapf(err, "failed to upload layer %d", idx)
 	}
@@ -180,8 +174,8 @@ func (e *fastOCIBuilderEngine) UploadImage(ctx context.Context) error {
 		Digest:    "sha256:c3a417552a6cf9ffa959b541850bab7d7f08f4255425bf8b48c85f7b36b378d9",
 		Size:      4737695,
 		Annotations: map[string]string{
-			labelKeyOverlayBDBlobDigest: "sha256:c3a417552a6cf9ffa959b541850bab7d7f08f4255425bf8b48c85f7b36b378d9",
-			labelKeyOverlayBDBlobSize:   "4737695",
+			label.OverlayBDBlobDigest: "sha256:c3a417552a6cf9ffa959b541850bab7d7f08f4255425bf8b48c85f7b36b378d9",
+			label.OverlayBDBlobSize:   "4737695",
 		},
 	}
 	if err := uploadBlob(ctx, e.pusher, overlaybdBaseLayer, baseDesc); err != nil {

--- a/cmd/convertor/builder/fastoci_builder.go
+++ b/cmd/convertor/builder/fastoci_builder.go
@@ -1,0 +1,254 @@
+/*
+   Copyright The Accelerated Container Image Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package builder
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+
+	"github.com/containerd/accelerated-container-image/pkg/snapshot"
+	"github.com/containerd/containerd/archive/compression"
+	"github.com/containerd/containerd/images"
+	"github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+const (
+	// labelKeyFastOCIImageRef is the index annotation key for image layer digest
+	labelKeyFastOCIDigest = "containerd.io/snapshot/overlaybd/fastoci/target-digest"
+
+	// labelKeyFastOCIMediaType is the index annotation key for image layer media type,
+	// indicate if image layer is in gzip format or not
+	labelKeyFastOCIMediaType = "containerd.io/snapshot/overlaybd/fastoci/target-media-type"
+
+	// index of OCI layers (gzip)
+	gzipMetaFile = "gzip.meta"
+
+	// index of block device
+	fsMetaFile = "ext4.fs.meta"
+
+	// foci index layer (gzip)
+	fociLayerTar = "foci.tar.gz"
+
+	// fociIdentifier is an empty file just used as a identifier
+	fociIdentifier = ".fastoci.overlaybd"
+)
+
+type fastOCIBuilderEngine struct {
+	*builderEngineBase
+	overlaybdConfig *snapshot.OverlayBDBSConfig
+	fociLayers      []specs.Descriptor
+	isGzip          []bool
+}
+
+func NewFastOCIBuilderEngine(base *builderEngineBase) builderEngine {
+	config := &snapshot.OverlayBDBSConfig{
+		Lowers:     []snapshot.OverlayBDBSConfigLower{},
+		ResultFile: "",
+	}
+	config.Lowers = append(config.Lowers, snapshot.OverlayBDBSConfigLower{
+		File: overlaybdBaseLayer,
+	})
+	return &fastOCIBuilderEngine{
+		builderEngineBase: base,
+		overlaybdConfig:   config,
+		fociLayers:        make([]specs.Descriptor, len(base.manifest.Layers)),
+		isGzip:            make([]bool, len(base.manifest.Layers)),
+	}
+}
+
+func (e *fastOCIBuilderEngine) DownloadLayer(ctx context.Context, idx int) error {
+	var err error
+	if e.isGzip[idx], err = e.isGzipLayer(ctx, idx); err != nil {
+		return err
+	}
+
+	desc := e.manifest.Layers[idx]
+	targetFile := path.Join(e.getLayerDir(idx), "layer.tar")
+	return downloadLayer(ctx, e.fetcher, targetFile, desc, false)
+}
+
+func (e *fastOCIBuilderEngine) BuildLayer(ctx context.Context, idx int) error {
+	layerDir := e.getLayerDir(idx)
+	if err := e.create(ctx, layerDir); err != nil {
+		return err
+	}
+	e.overlaybdConfig.Upper = snapshot.OverlayBDBSConfigUpper{
+		Data:   path.Join(layerDir, "writable_data"),
+		Index:  path.Join(layerDir, "writable_index"),
+		Target: path.Join(layerDir, "layer.tar"),
+	}
+	if err := writeConfig(layerDir, e.overlaybdConfig); err != nil {
+		return err
+	}
+	if err := e.apply(ctx, layerDir); err != nil {
+		return err
+	}
+	if err := e.commit(ctx, layerDir); err != nil {
+		return err
+	}
+	if err := e.createIdentifier(idx); err != nil {
+		return errors.Wrapf(err, "failed to create identifier %q", fociIdentifier)
+	}
+	files := []string{
+		path.Join(layerDir, fsMetaFile),
+		path.Join(layerDir, fociIdentifier),
+	}
+	gzipIndexPath := ""
+	if e.isGzip[idx] {
+		gzipIndexPath = path.Join(layerDir, gzipMetaFile)
+		files = append(files, gzipIndexPath)
+	}
+	if err := buildArchiveFromFiles(ctx, path.Join(layerDir, fociLayerTar), compression.Gzip, files...); err != nil {
+		return errors.Wrapf(err, "failed to create foci archive for layer %d", idx)
+	}
+	e.overlaybdConfig.Lowers = append(e.overlaybdConfig.Lowers, snapshot.OverlayBDBSConfigLower{
+		TargetFile: path.Join(layerDir, "layer.tar"),
+		File:       path.Join(layerDir, fsMetaFile),
+		GzipIndex:  gzipIndexPath,
+	})
+	os.Remove(path.Join(layerDir, "writable_data"))
+	os.Remove(path.Join(layerDir, "writable_index"))
+	return nil
+}
+
+func (e *fastOCIBuilderEngine) UploadLayer(ctx context.Context, idx int) error {
+	layerDir := e.getLayerDir(idx)
+	desc, err := getFileDesc(path.Join(layerDir, fociLayerTar), false)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get descriptor for layer %d", idx)
+	}
+	desc.MediaType = e.mediaTypeImageLayerGzip()
+	desc.Annotations = map[string]string{
+		labelKeyOverlayBDBlobDigest: desc.Digest.String(),
+		labelKeyOverlayBDBlobSize:   fmt.Sprintf("%d", desc.Size),
+		labelKeyFastOCIDigest:       e.manifest.Layers[idx].Digest.String(),
+	}
+	targetMediaType := ""
+	if images.IsDockerType(e.manifest.Layers[idx].MediaType) {
+		if e.isGzip[idx] {
+			targetMediaType = images.MediaTypeDockerSchema2LayerGzip
+		} else {
+			targetMediaType = images.MediaTypeDockerSchema2Layer
+		}
+	} else {
+		if e.isGzip[idx] {
+			targetMediaType = specs.MediaTypeImageLayerGzip
+		} else {
+			targetMediaType = specs.MediaTypeImageLayer
+		}
+	}
+	desc.Annotations[labelKeyFastOCIMediaType] = targetMediaType
+	if err := uploadBlob(ctx, e.pusher, path.Join(layerDir, fociLayerTar), desc); err != nil {
+		return errors.Wrapf(err, "failed to upload layer %d", idx)
+	}
+	e.fociLayers[idx] = desc
+	return nil
+}
+
+func (e *fastOCIBuilderEngine) UploadImage(ctx context.Context) error {
+	for idx := range e.manifest.Layers {
+		layerDir := e.getLayerDir(idx)
+		uncompress, err := getFileDesc(path.Join(layerDir, fociLayerTar), true)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get uncompressed descriptor for layer %d", idx)
+		}
+		e.manifest.Layers[idx] = e.fociLayers[idx]
+		e.config.RootFS.DiffIDs[idx] = uncompress.Digest
+	}
+	baseDesc := specs.Descriptor{
+		MediaType: e.mediaTypeImageLayer(),
+		Digest:    "sha256:c3a417552a6cf9ffa959b541850bab7d7f08f4255425bf8b48c85f7b36b378d9",
+		Size:      4737695,
+		Annotations: map[string]string{
+			labelKeyOverlayBDBlobDigest: "sha256:c3a417552a6cf9ffa959b541850bab7d7f08f4255425bf8b48c85f7b36b378d9",
+			labelKeyOverlayBDBlobSize:   "4737695",
+		},
+	}
+	if err := uploadBlob(ctx, e.pusher, overlaybdBaseLayer, baseDesc); err != nil {
+		return errors.Wrapf(err, "failed to upload baselayer %q", overlaybdBaseLayer)
+	}
+	e.manifest.Layers = append([]specs.Descriptor{baseDesc}, e.manifest.Layers...)
+	e.config.RootFS.DiffIDs = append([]digest.Digest{baseDesc.Digest}, e.config.RootFS.DiffIDs...)
+	return e.uploadManifestAndConfig(ctx)
+}
+
+func (e *fastOCIBuilderEngine) Cleanup() {
+	os.RemoveAll(e.workDir)
+}
+
+func (e *fastOCIBuilderEngine) getLayerDir(idx int) string {
+	return path.Join(e.workDir, fmt.Sprintf("%04d_", idx)+e.manifest.Layers[idx].Digest.String())
+}
+
+func (e *fastOCIBuilderEngine) createIdentifier(idx int) error {
+	targetFile := path.Join(e.getLayerDir(idx), fociIdentifier)
+	file, err := os.Create(targetFile)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create identifier file %q", fociIdentifier)
+	}
+	defer file.Close()
+	return nil
+}
+
+func (e *fastOCIBuilderEngine) create(ctx context.Context, dir string) error {
+	binpath := filepath.Join("/opt/overlaybd/bin", "overlaybd-create")
+	dataPath := path.Join(dir, "writable_data")
+	indexPath := path.Join(dir, "writable_index")
+	os.RemoveAll(dataPath)
+	os.RemoveAll(indexPath)
+	out, err := exec.CommandContext(ctx, binpath, "-s",
+		dataPath, indexPath, "64", "--fastoci").CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "failed to overlaybd-create: %s", out)
+	}
+	return nil
+}
+
+func (e *fastOCIBuilderEngine) apply(ctx context.Context, dir string) error {
+	binpath := filepath.Join("/opt/overlaybd/bin", "overlaybd-apply")
+
+	out, err := exec.CommandContext(ctx, binpath,
+		path.Join(dir, "layer.tar"),
+		path.Join(dir, "config.json"),
+		"--gz_index_path", path.Join(dir, gzipMetaFile),
+	).CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "failed to overlaybd-apply: %s", out)
+	}
+	return nil
+}
+
+func (e *fastOCIBuilderEngine) commit(ctx context.Context, dir string) error {
+	binpath := filepath.Join("/opt/overlaybd/bin", "overlaybd-commit")
+
+	out, err := exec.CommandContext(ctx, binpath, "-z",
+		path.Join(dir, "writable_data"),
+		path.Join(dir, "writable_index"),
+		path.Join(dir, fsMetaFile),
+		"--fastoci",
+	).CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "failed to overlaybd-commit: %s", out)
+	}
+	return nil
+}

--- a/cmd/convertor/builder/overlaybd_builder.go
+++ b/cmd/convertor/builder/overlaybd_builder.go
@@ -1,0 +1,192 @@
+/*
+   Copyright The Accelerated Container Image Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package builder
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+
+	"github.com/containerd/accelerated-container-image/pkg/snapshot"
+	"github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+const (
+	// labelKeyOverlayBDBlobDigest is the annotation key in the manifest to
+	// describe the digest of blob in OverlayBD format.
+	//
+	// NOTE: The annotation is part of image layer blob's descriptor.
+	labelKeyOverlayBDBlobDigest = "containerd.io/snapshot/overlaybd/blob-digest"
+
+	// labelKeyOverlayBDBlobSize is the annotation key in the manifest to
+	// describe the size of blob in OverlayBD format.
+	//
+	// NOTE: The annotation is part of image layer blob's descriptor.
+	labelKeyOverlayBDBlobSize = "containerd.io/snapshot/overlaybd/blob-size"
+
+	overlaybdBaseLayer = "/opt/overlaybd/baselayers/ext4_64"
+
+	commitFile = "overlaybd.commit"
+)
+
+type overlaybdBuilderEngine struct {
+	*builderEngineBase
+	overlaybdConfig *snapshot.OverlayBDBSConfig
+	overlaybdLayers []specs.Descriptor
+}
+
+func NewOverlayBDBuilderEngine(base *builderEngineBase) builderEngine {
+	config := &snapshot.OverlayBDBSConfig{
+		Lowers:     []snapshot.OverlayBDBSConfigLower{},
+		ResultFile: "",
+	}
+	config.Lowers = append(config.Lowers, snapshot.OverlayBDBSConfigLower{
+		File: overlaybdBaseLayer,
+	})
+	return &overlaybdBuilderEngine{
+		builderEngineBase: base,
+		overlaybdConfig:   config,
+		overlaybdLayers:   make([]specs.Descriptor, len(base.manifest.Layers)),
+	}
+}
+
+func (e *overlaybdBuilderEngine) DownloadLayer(ctx context.Context, idx int) error {
+	desc := e.manifest.Layers[idx]
+	targetFile := path.Join(e.getLayerDir(idx), "layer.tar")
+	return downloadLayer(ctx, e.fetcher, targetFile, desc, true)
+}
+
+func (e *overlaybdBuilderEngine) BuildLayer(ctx context.Context, idx int) error {
+	layerDir := e.getLayerDir(idx)
+	if err := e.create(ctx, layerDir); err != nil {
+		return err
+	}
+	e.overlaybdConfig.Upper = snapshot.OverlayBDBSConfigUpper{
+		Data:  path.Join(layerDir, "writable_data"),
+		Index: path.Join(layerDir, "writable_index"),
+	}
+	if err := writeConfig(layerDir, e.overlaybdConfig); err != nil {
+		return err
+	}
+	if err := e.apply(ctx, layerDir); err != nil {
+		return err
+	}
+	if err := e.commit(ctx, layerDir); err != nil {
+		return err
+	}
+	e.overlaybdConfig.Lowers = append(e.overlaybdConfig.Lowers, snapshot.OverlayBDBSConfigLower{
+		File: path.Join(layerDir, commitFile),
+	})
+	os.Remove(path.Join(layerDir, "layer.tar"))
+	os.Remove(path.Join(layerDir, "writable_data"))
+	os.Remove(path.Join(layerDir, "writable_index"))
+	return nil
+}
+
+func (e *overlaybdBuilderEngine) UploadLayer(ctx context.Context, idx int) error {
+	layerDir := e.getLayerDir(idx)
+	desc, err := getFileDesc(path.Join(layerDir, commitFile), false)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get descriptor for layer %d", idx)
+	}
+	desc.MediaType = e.mediaTypeImageLayerGzip()
+	desc.Annotations = map[string]string{
+		labelKeyOverlayBDBlobDigest: desc.Digest.String(),
+		labelKeyOverlayBDBlobSize:   fmt.Sprintf("%d", desc.Size),
+	}
+	if err := uploadBlob(ctx, e.pusher, path.Join(layerDir, commitFile), desc); err != nil {
+		return errors.Wrapf(err, "failed to upload layer %d", idx)
+	}
+	e.overlaybdLayers[idx] = desc
+	return nil
+}
+
+func (e *overlaybdBuilderEngine) UploadImage(ctx context.Context) error {
+	for idx := range e.manifest.Layers {
+		e.manifest.Layers[idx] = e.overlaybdLayers[idx]
+		e.config.RootFS.DiffIDs[idx] = e.overlaybdLayers[idx].Digest
+	}
+	baseDesc := specs.Descriptor{
+		MediaType: e.mediaTypeImageLayer(),
+		Digest:    "sha256:c3a417552a6cf9ffa959b541850bab7d7f08f4255425bf8b48c85f7b36b378d9",
+		Size:      4737695,
+		Annotations: map[string]string{
+			labelKeyOverlayBDBlobDigest: "sha256:c3a417552a6cf9ffa959b541850bab7d7f08f4255425bf8b48c85f7b36b378d9",
+			labelKeyOverlayBDBlobSize:   "4737695",
+		},
+	}
+	if err := uploadBlob(ctx, e.pusher, overlaybdBaseLayer, baseDesc); err != nil {
+		return errors.Wrapf(err, "failed to upload baselayer %q", overlaybdBaseLayer)
+	}
+	e.manifest.Layers = append([]specs.Descriptor{baseDesc}, e.manifest.Layers...)
+	e.config.RootFS.DiffIDs = append([]digest.Digest{baseDesc.Digest}, e.config.RootFS.DiffIDs...)
+	return e.uploadManifestAndConfig(ctx)
+}
+
+func (e *overlaybdBuilderEngine) Cleanup() {
+	os.RemoveAll(e.workDir)
+}
+
+func (e *overlaybdBuilderEngine) getLayerDir(idx int) string {
+	return path.Join(e.workDir, fmt.Sprintf("%04d_", idx)+e.manifest.Layers[idx].Digest.String())
+}
+
+func (e *overlaybdBuilderEngine) create(ctx context.Context, dir string) error {
+	binpath := filepath.Join("/opt/overlaybd/bin", "overlaybd-create")
+	dataPath := path.Join(dir, "writable_data")
+	indexPath := path.Join(dir, "writable_index")
+	os.RemoveAll(dataPath)
+	os.RemoveAll(indexPath)
+	out, err := exec.CommandContext(ctx, binpath, "-s",
+		dataPath, indexPath, "64").CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "failed to overlaybd-create: %s", out)
+	}
+	return nil
+}
+
+func (e *overlaybdBuilderEngine) apply(ctx context.Context, dir string) error {
+	binpath := filepath.Join("/opt/overlaybd/bin", "overlaybd-apply")
+
+	out, err := exec.CommandContext(ctx, binpath,
+		path.Join(dir, "layer.tar"),
+		path.Join(dir, "config.json"),
+	).CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "failed to overlaybd-apply: %s", out)
+	}
+	return nil
+}
+
+func (e *overlaybdBuilderEngine) commit(ctx context.Context, dir string) error {
+	binpath := filepath.Join("/opt/overlaybd/bin", "overlaybd-commit")
+
+	out, err := exec.CommandContext(ctx, binpath, "-z",
+		path.Join(dir, "writable_data"),
+		path.Join(dir, "writable_index"),
+		path.Join(dir, commitFile),
+	).CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "failed to overlaybd-commit: %s", out)
+	}
+	return nil
+}

--- a/cmd/convertor/builder/overlaybd_builder.go
+++ b/cmd/convertor/builder/overlaybd_builder.go
@@ -24,6 +24,7 @@ import (
 	"path"
 	"path/filepath"
 
+	"github.com/containerd/accelerated-container-image/pkg/label"
 	"github.com/containerd/accelerated-container-image/pkg/snapshot"
 	"github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -31,18 +32,6 @@ import (
 )
 
 const (
-	// labelKeyOverlayBDBlobDigest is the annotation key in the manifest to
-	// describe the digest of blob in OverlayBD format.
-	//
-	// NOTE: The annotation is part of image layer blob's descriptor.
-	labelKeyOverlayBDBlobDigest = "containerd.io/snapshot/overlaybd/blob-digest"
-
-	// labelKeyOverlayBDBlobSize is the annotation key in the manifest to
-	// describe the size of blob in OverlayBD format.
-	//
-	// NOTE: The annotation is part of image layer blob's descriptor.
-	labelKeyOverlayBDBlobSize = "containerd.io/snapshot/overlaybd/blob-size"
-
 	overlaybdBaseLayer = "/opt/overlaybd/baselayers/ext4_64"
 
 	commitFile = "overlaybd.commit"
@@ -110,8 +99,8 @@ func (e *overlaybdBuilderEngine) UploadLayer(ctx context.Context, idx int) error
 	}
 	desc.MediaType = e.mediaTypeImageLayerGzip()
 	desc.Annotations = map[string]string{
-		labelKeyOverlayBDBlobDigest: desc.Digest.String(),
-		labelKeyOverlayBDBlobSize:   fmt.Sprintf("%d", desc.Size),
+		label.OverlayBDBlobDigest: desc.Digest.String(),
+		label.OverlayBDBlobSize:   fmt.Sprintf("%d", desc.Size),
 	}
 	if err := uploadBlob(ctx, e.pusher, path.Join(layerDir, commitFile), desc); err != nil {
 		return errors.Wrapf(err, "failed to upload layer %d", idx)
@@ -130,8 +119,8 @@ func (e *overlaybdBuilderEngine) UploadImage(ctx context.Context) error {
 		Digest:    "sha256:c3a417552a6cf9ffa959b541850bab7d7f08f4255425bf8b48c85f7b36b378d9",
 		Size:      4737695,
 		Annotations: map[string]string{
-			labelKeyOverlayBDBlobDigest: "sha256:c3a417552a6cf9ffa959b541850bab7d7f08f4255425bf8b48c85f7b36b378d9",
-			labelKeyOverlayBDBlobSize:   "4737695",
+			label.OverlayBDBlobDigest: "sha256:c3a417552a6cf9ffa959b541850bab7d7f08f4255425bf8b48c85f7b36b378d9",
+			label.OverlayBDBlobSize:   "4737695",
 		},
 	}
 	if err := uploadBlob(ctx, e.pusher, overlaybdBaseLayer, baseDesc); err != nil {

--- a/cmd/convertor/main.go
+++ b/cmd/convertor/main.go
@@ -17,31 +17,11 @@
 package main
 
 import (
-	"bytes"
 	"context"
-	"crypto/sha256"
-	"encoding/json"
-	"fmt"
-	"io"
 	"os"
-	"os/exec"
 	"os/signal"
-	"path"
-	"path/filepath"
-	"strings"
-	"sync"
 
-	"github.com/containerd/accelerated-container-image/pkg/snapshot"
-	"github.com/containerd/containerd/archive/compression"
-	"github.com/containerd/containerd/content"
-	"github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/images"
-	"github.com/containerd/containerd/remotes"
-	"github.com/containerd/containerd/remotes/docker"
-	"github.com/containerd/continuity"
-	"github.com/opencontainers/go-digest"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
+	"github.com/containerd/accelerated-container-image/cmd/convertor/builder"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -54,368 +34,63 @@ var (
 	tagOutput string
 	dir       string
 	oci       bool
+	fastoci   string
+	overlaybd string
 
 	rootCmd = &cobra.Command{
 		Use:   "convertor",
 		Short: "An image conversion tool from oci image to overlaybd image.",
 		Long:  "overlaybd convertor is a standalone userspace image conversion tool that helps converting oci images to overlaybd images",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := convert(); err != nil {
-				logrus.Errorf("run with error: %v", err)
-				os.Exit(1)
+			if overlaybd == "" && fastoci == "" {
+				if tagOutput == "" {
+					logrus.Error("output-tag is required, you can specify it by [-o|--overlaybd|--fastoci]")
+					os.Exit(1)
+				}
+				overlaybd = tagOutput
+			}
+
+			ctx := context.Background()
+			opt := builder.BuilderOptions{
+				Ref:       repo + ":" + tagInput,
+				Auth:      user,
+				PlainHTTP: plain,
+				WorkDir:   dir,
+				OCI:       oci,
+			}
+			if overlaybd != "" {
+				logrus.Info("building overlaybd ...")
+				opt.Engine = builder.BuilderEngineTypeOverlayBD
+				opt.TargetRef = repo + ":" + overlaybd
+				builder, err := builder.NewOverlayBDBuilder(ctx, opt)
+				if err != nil {
+					logrus.Errorf("failed to create overlaybd builder: %v", err)
+					os.Exit(1)
+				}
+				if err := builder.Build(ctx); err != nil {
+					logrus.Errorf("failed to build overlaybd: %v", err)
+					os.Exit(1)
+				}
+				logrus.Info("overlaybd build finished")
+			}
+			if fastoci != "" {
+				logrus.Info("building fastoci ...")
+				opt.Engine = builder.BuilderEngineTypeFastOCI
+				opt.TargetRef = repo + ":" + fastoci
+				builder, err := builder.NewOverlayBDBuilder(ctx, opt)
+				if err != nil {
+					logrus.Errorf("failed to create fastoci builder: %v", err)
+					os.Exit(1)
+				}
+				if err := builder.Build(ctx); err != nil {
+					logrus.Errorf("failed to build fastoci: %v", err)
+					os.Exit(1)
+				}
+				logrus.Info("fastoci build finished")
 			}
 		},
 	}
 )
-
-func prepareWritableLayer(ctx context.Context, dir string) error {
-	binpath := filepath.Join("/opt/overlaybd/bin", "overlaybd-create")
-	dataPath := path.Join(dir, "writable_data")
-	indexPath := path.Join(dir, "writable_index")
-	os.RemoveAll(dataPath)
-	os.RemoveAll(indexPath)
-	out, err := exec.CommandContext(ctx, binpath, "-s",
-		dataPath, indexPath, "64").CombinedOutput()
-	if err != nil {
-		return errors.Wrapf(err, "failed to prepare writable layer: %s", out)
-	}
-	return nil
-}
-
-func writeConfig(dir string, configJSON *snapshot.OverlayBDBSConfig) error {
-	data, err := json.Marshal(configJSON)
-	if err != nil {
-		return err
-	}
-
-	confPath := path.Join(dir, "config.json")
-	if err := continuity.AtomicWriteFile(confPath, data, 0600); err != nil {
-		return err
-	}
-	return nil
-}
-
-func overlaybdApply(ctx context.Context, dir string) error {
-	binpath := filepath.Join("/opt/overlaybd/bin", "overlaybd-apply")
-
-	out, err := exec.CommandContext(ctx, binpath,
-		path.Join(dir, "layer.tar"),
-		path.Join(dir, "config.json")).CombinedOutput()
-	if err != nil {
-		return errors.Wrapf(err, "failed to apply tar to overlaybd: %s", out)
-	}
-	return nil
-}
-
-func overlaybdCommit(ctx context.Context, dir string) error {
-	binpath := filepath.Join("/opt/overlaybd/bin", "overlaybd-commit")
-
-	out, err := exec.CommandContext(ctx, binpath, "-z",
-		path.Join(dir, "writable_data"),
-		path.Join(dir, "writable_index"),
-		path.Join(dir, "overlaybd.commit")).CombinedOutput()
-	if err != nil {
-		return errors.Wrapf(err, "failed to commit overlaybd: %s", out)
-	}
-	return nil
-}
-
-func makeDesc(dir string, layerMediaType string) (specs.Descriptor, error) {
-	commitFile := path.Join(dir, "overlaybd.commit")
-	file, err := os.Open(commitFile)
-	if err != nil {
-		return specs.Descriptor{}, err
-	}
-	defer file.Close()
-
-	h := sha256.New()
-	size, err := io.Copy(h, file)
-	if err != nil {
-		return specs.Descriptor{}, err
-	}
-	dgst := digest.NewDigest(digest.SHA256, h)
-	return specs.Descriptor{
-		MediaType: layerMediaType,
-		Digest:    dgst,
-		Size:      size,
-		Annotations: map[string]string{
-			"containerd.io/snapshot/overlaybd/blob-digest": dgst.String(),
-			"containerd.io/snapshot/overlaybd/blob-size":   fmt.Sprintf("%d", size),
-		},
-	}, nil
-}
-
-func uploadBlob(ctx context.Context, pusher remotes.Pusher, path string, desc specs.Descriptor) error {
-	cw, err := pusher.Push(ctx, desc)
-	if err != nil {
-		if errdefs.IsAlreadyExists(err) {
-			logrus.Infof("layer %s exists", desc.Digest.String())
-			return nil
-		}
-		return err
-	}
-
-	defer cw.Close()
-	fobd, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	defer fobd.Close()
-	if err = content.Copy(ctx, cw, fobd, desc.Size, desc.Digest); err != nil {
-		return err
-	}
-	return nil
-}
-
-func uploadBytes(ctx context.Context, pusher remotes.Pusher, desc specs.Descriptor, data []byte) error {
-	cw, err := pusher.Push(ctx, desc)
-	if err != nil {
-		if errdefs.IsAlreadyExists(err) {
-			logrus.Infof("content %s exists", desc.Digest.String())
-			return nil
-		}
-		return err
-	}
-	defer cw.Close()
-
-	err = content.Copy(ctx, cw, bytes.NewReader(data), desc.Size, desc.Digest)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func convert() error {
-	ctx := context.Background()
-	defer func() {
-		// clean temp data
-		os.RemoveAll(dir)
-	}()
-
-	resolver := docker.NewResolver(docker.ResolverOptions{
-		Credentials: func(s string) (string, string, error) {
-			if user == "" {
-				return "", "", nil
-			}
-			userSplit := strings.Split(user, ":")
-			return userSplit[0], userSplit[1], nil
-		},
-		PlainHTTP: plain,
-	})
-
-	ref := repo + ":" + tagInput
-	_, desc, err := resolver.Resolve(ctx, ref)
-	if err != nil {
-		return errors.Wrapf(err, "failed to resolve reference %q", ref)
-	}
-
-	fetcher, err := resolver.Fetcher(ctx, ref)
-	if err != nil {
-		return errors.Wrapf(err, "failed to get fetcher for %q", ref)
-	}
-
-	targetRef := repo + ":" + tagOutput
-	pusher, err := resolver.Pusher(ctx, targetRef)
-	if err != nil {
-		return errors.Wrapf(err, "failed to get pusher for %q", targetRef)
-	}
-
-	rc, err := fetcher.Fetch(ctx, desc)
-	if err != nil {
-		return errors.Wrapf(err, "failed to fetch manifest")
-	}
-	buf, err := io.ReadAll(rc)
-	if err != nil {
-		return errors.Wrapf(err, "failed to fetch manifest")
-	}
-	rc.Close()
-
-	manifest := specs.Manifest{}
-	err = json.Unmarshal(buf, &manifest)
-	if err != nil {
-		return err
-	}
-
-	rc, err = fetcher.Fetch(ctx, manifest.Config)
-	if err != nil {
-		return errors.Wrapf(err, "failed to fetch config")
-	}
-	buf, err = io.ReadAll(rc)
-	if err != nil {
-		return errors.Wrapf(err, "failed to fetch config")
-	}
-	rc.Close()
-
-	config := specs.Image{}
-	if err = json.Unmarshal(buf, &config); err != nil {
-		return err
-	}
-
-	configJSON := snapshot.OverlayBDBSConfig{
-		Lowers:     []snapshot.OverlayBDBSConfigLower{},
-		ResultFile: "",
-	}
-	configJSON.Lowers = append(configJSON.Lowers, snapshot.OverlayBDBSConfigLower{
-		File: "/opt/overlaybd/baselayers/ext4_64",
-	})
-
-	results := make(chan error)
-	var waitGroup sync.WaitGroup
-	waitGroup.Add(len(manifest.Layers))
-	for idx, layer := range manifest.Layers {
-		go func(idx int, layer specs.Descriptor) {
-			rc, err := fetcher.Fetch(ctx, layer)
-			if err != nil {
-				results <- errors.Wrapf(err, "failed to download for layer %d", idx)
-				return
-			}
-			drc, err := compression.DecompressStream(rc)
-			if err != nil {
-				results <- errors.Wrapf(err, "failed to decompress for layer %d", idx)
-				return
-			}
-			layerDir := path.Join(dir, fmt.Sprintf("%04d_", idx)+layer.Digest.String())
-			if err = os.MkdirAll(layerDir, 0644); err != nil {
-				results <- err
-				return
-			}
-			ftar, err := os.Create(path.Join(layerDir, "layer.tar"))
-			if err != nil {
-				results <- err
-				return
-			}
-			if _, err = io.Copy(ftar, drc); err != nil {
-				results <- errors.Wrapf(err, "failed to decompress copy for layer %d", idx)
-				return
-			}
-			logrus.Infof("downloaded layer %d, dir %s", idx, layerDir)
-			waitGroup.Done()
-		}(idx, layer)
-	}
-
-	waitGroup.Wait()
-	close(results)
-	for result := range results {
-		if result != nil {
-			return result
-		}
-	}
-
-	layerMediaType := images.MediaTypeDockerSchema2Layer
-	if oci {
-		layerMediaType = specs.MediaTypeImageLayer
-	}
-	lastDigest := ""
-	for idx, layer := range manifest.Layers {
-		layerDir := path.Join(dir, fmt.Sprintf("%04d_", idx)+layer.Digest.String())
-		// TODO check diffID
-
-		// make writable layer
-		if err = prepareWritableLayer(ctx, layerDir); err != nil {
-			return errors.Wrapf(err, "failed to overlaybd create for layer %d", idx)
-		}
-
-		// make config
-		if idx > 0 {
-			configJSON.Lowers = append(configJSON.Lowers, snapshot.OverlayBDBSConfigLower{
-				File: path.Join(dir, lastDigest, "overlaybd.commit"),
-			})
-		}
-		configJSON.Upper = snapshot.OverlayBDBSConfigUpper{
-			Data:  path.Join(layerDir, "writable_data"),
-			Index: path.Join(layerDir, "writable_index"),
-		}
-		if err = writeConfig(layerDir, &configJSON); err != nil {
-			return err
-		}
-
-		// apply and commit
-		if err = overlaybdApply(ctx, layerDir); err != nil {
-			return errors.Wrapf(err, "failed to overlaybd apply for layer %d", idx)
-		}
-		if err = overlaybdCommit(ctx, layerDir); err != nil {
-			return errors.Wrapf(err, "failed to overlaybd commit for layer %d", idx)
-		}
-		//for test
-		// os.Rename(path.Join(layerDir, "layer.tar"), path.Join(layerDir, "overlaybd.commit"))
-
-		//calc digest
-		desc, err := makeDesc(layerDir, layerMediaType)
-		if err != nil {
-			return errors.Wrapf(err, "failed to make descriptor for layer %d", idx)
-		}
-
-		// upload
-		if err = uploadBlob(ctx, pusher, path.Join(layerDir, "overlaybd.commit"), desc); err != nil {
-			return errors.Wrapf(err, "failed to upload layer %d", idx)
-		}
-		logrus.Infof("layer %d uploaded", idx)
-
-		lastDigest = fmt.Sprintf("%04d_", idx) + manifest.Layers[idx].Digest.String()
-		manifest.Layers[idx] = desc
-		config.RootFS.DiffIDs[idx] = desc.Digest
-
-		// clean unused file
-		os.Remove(path.Join(dir, lastDigest, "layer.tar"))
-		os.Remove(path.Join(dir, lastDigest, "writable_data"))
-		os.Remove(path.Join(dir, lastDigest, "writable_index"))
-	}
-
-	// add baselayer
-	baseDesc := specs.Descriptor{
-		MediaType: layerMediaType,
-		Digest:    "sha256:c3a417552a6cf9ffa959b541850bab7d7f08f4255425bf8b48c85f7b36b378d9",
-		Size:      4737695,
-		Annotations: map[string]string{
-			"containerd.io/snapshot/overlaybd/blob-digest": "sha256:c3a417552a6cf9ffa959b541850bab7d7f08f4255425bf8b48c85f7b36b378d9",
-			"containerd.io/snapshot/overlaybd/blob-size":   "4737695",
-		},
-	}
-	if err = uploadBlob(ctx, pusher, "/opt/overlaybd/baselayers/ext4_64", baseDesc); err != nil {
-		return errors.Wrapf(err, "failed to upload baselayer")
-	}
-	manifest.Layers = append([]specs.Descriptor{baseDesc}, manifest.Layers...)
-	config.RootFS.DiffIDs = append([]digest.Digest{baseDesc.Digest}, config.RootFS.DiffIDs...)
-
-	// upload config and manifest
-	cbuf, err := json.Marshal(config)
-	if err != nil {
-		return err
-	}
-	configMediaType := images.MediaTypeDockerSchema2Config
-	if oci {
-		configMediaType = specs.MediaTypeImageConfig
-	}
-	manifest.Config = specs.Descriptor{
-		MediaType: configMediaType,
-		Digest:    digest.FromBytes(cbuf),
-		Size:      (int64)(len(cbuf)),
-	}
-	if err = uploadBytes(ctx, pusher, manifest.Config, cbuf); err != nil {
-		return errors.Wrapf(err, "failed to upload config")
-	}
-	manifestMediaType := images.MediaTypeDockerSchema2Manifest
-	if oci {
-		manifestMediaType = specs.MediaTypeImageManifest
-	}
-	manifest.MediaType = manifestMediaType
-	cbuf, err = json.Marshal(manifest)
-	if err != nil {
-		return err
-	}
-	manifestDesc := specs.Descriptor{
-		MediaType: manifestMediaType,
-		Digest:    digest.FromBytes(cbuf),
-		Size:      (int64)(len(cbuf)),
-	}
-
-	if err = uploadBytes(ctx, pusher, manifestDesc, cbuf); err != nil {
-		return errors.Wrapf(err, "failed to upload manifest")
-	}
-	logrus.Infof("convert finished")
-
-	return nil
-}
 
 func init() {
 	rootCmd.Flags().SortFlags = false
@@ -426,10 +101,11 @@ func init() {
 	rootCmd.Flags().StringVarP(&tagOutput, "output-tag", "o", "", "tag for image converting to (required)")
 	rootCmd.Flags().StringVarP(&dir, "dir", "d", "tmp_conv", "directory used for temporary data")
 	rootCmd.Flags().BoolVarP(&oci, "oci", "", false, "export image with oci spec")
+	rootCmd.Flags().StringVar(&fastoci, "fastoci", "", "build fastoci format")
+	rootCmd.Flags().StringVar(&overlaybd, "overlaybd", "", "build overlaybd format")
 
 	rootCmd.MarkFlagRequired("repository")
 	rootCmd.MarkFlagRequired("input-tag")
-	rootCmd.MarkFlagRequired("output-tag")
 }
 
 func main() {

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -1,0 +1,106 @@
+/*
+   Copyright The Accelerated Container Image Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package label
+
+// support on-demand loading by the labels
+const (
+	// TargetSnapshotRef is the interface to know that Prepare
+	// action is to pull image, not for container Writable snapshot.
+	//
+	// NOTE: Only available in >= containerd 1.4.0 and containerd.Pull
+	// with Unpack option.
+	//
+	// FIXME(fuweid): With containerd design, we don't know that what purpose
+	// snapshotter.Prepare does for. For unpacked image, prepare is for
+	// container's rootfs. For pulling image, the prepare is for committed.
+	// With label "containerd.io/snapshot.ref" in preparing, snapshotter
+	// author will know it is for pulling image. It will be useful.
+	//
+	// The label is only propagated during pulling image. So, is it possible
+	// to propagate by image.Unpack()?
+	TargetSnapshotRef = "containerd.io/snapshot.ref"
+
+	// TargetImageRef is the label to mark where the snapshot comes from.
+	//
+	// TODO(fuweid): Is it possible to use it in upstream?
+	TargetImageRef = "containerd.io/snapshot/image-ref"
+
+	// OverlayBDBlobDigest is the annotation key in the manifest to
+	// describe the digest of blob in OverlayBD format.
+	//
+	// NOTE: The annotation is part of image layer blob's descriptor.
+	OverlayBDBlobDigest = "containerd.io/snapshot/overlaybd/blob-digest"
+
+	// OverlayBDBlobSize is the annotation key in the manifest to
+	// describe the size of blob in OverlayBD format.
+	//
+	// NOTE: The annotation is part of image layer blob's descriptor.
+	OverlayBDBlobSize = "containerd.io/snapshot/overlaybd/blob-size"
+
+	// OverlayBDBlobFsType is the annotation key in the manifest to
+	// describe the filesystem type to be mounted as of blob in OverlayBD format.
+	//
+	// NOTE: The annotation is part of image layer blob's descriptor.
+	OverlayBDBlobFsType = "containerd.io/snapshot/overlaybd/blob-fs-type"
+
+	// AccelerationLayer is the annotation key in the manifest to indicate
+	// whether a top layer is acceleration layer or not.
+	AccelerationLayer = "containerd.io/snapshot/overlaybd/acceleration-layer"
+
+	// RecordTrace tells snapshotter to record trace
+	RecordTrace = "containerd.io/snapshot/overlaybd/record-trace"
+
+	// RecordTracePath is the the file path to record trace
+	RecordTracePath = "containerd.io/snapshot/overlaybd/record-trace-path"
+
+	// ZFileConfig is the config of ZFile
+	ZFileConfig = "containerd.io/snapshot/overlaybd/zfile-config"
+
+	// CRIImageRef is thr image-ref from cri
+	CRIImageRef = "containerd.io/snapshot/cri.image-ref"
+
+	// FastOCIDigest is the index annotation key for image layer digest
+	FastOCIDigest = "containerd.io/snapshot/overlaybd/fastoci/target-digest"
+
+	// FastOCIMediaType is the index annotation key for image layer media type
+	FastOCIMediaType = "containerd.io/snapshot/overlaybd/fastoci/target-media-type"
+
+	RemoteLabel    = "containerd.io/snapshot/remote"
+	RemoteLabelVal = "remote snapshot"
+)
+
+// interface
+const (
+	// SupportReadWriteMode is used to support writable block device
+	// for active snapshotter.
+	//
+	// By default, multiple active snapshotters can share one block device
+	// from parent snapshotter(committed). Like image builder and
+	// sandboxed-like container runtime(KataContainer, Firecracker), those
+	// cases want to use the block device alone or as writable.
+	// There are two ways to provide writable devices:
+	//  - 'dir' mark the snapshotter
+	//    as wriable block device and mount it on rootfs.
+	//  - 'dev' mark the snapshotter
+	//    as wriable block device without mount.
+	SupportReadWriteMode = "containerd.io/snapshot/overlaybd.writable"
+
+	// LocalOverlayBDPath is used to export the commit file path.
+	//
+	// NOTE: Only used in image build.
+	LocalOverlayBDPath = "containerd.io/snapshot/overlaybd.localcommitpath"
+)

--- a/pkg/snapshot/overlay.go
+++ b/pkg/snapshot/overlay.go
@@ -27,6 +27,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/containerd/accelerated-container-image/pkg/label"
 	"github.com/containerd/accelerated-container-image/pkg/metrics"
 
 	"github.com/containerd/containerd/errdefs"
@@ -58,95 +59,6 @@ const (
 	// storageTypeRemoteBlock means that there is no unpacked layer data.
 	// But there are labels to mark data that will be pulling on demand.
 	storageTypeRemoteBlock
-)
-
-// support on-demand loading by the labels
-const (
-	// labelKeyTargetSnapshotRef is the interface to know that Prepare
-	// action is to pull image, not for container Writable snapshot.
-	//
-	// NOTE: Only available in >= containerd 1.4.0 and containerd.Pull
-	// with Unpack option.
-	//
-	// FIXME(fuweid): With containerd design, we don't know that what purpose
-	// snapshotter.Prepare does for. For unpacked image, prepare is for
-	// container's rootfs. For pulling image, the prepare is for committed.
-	// With label "containerd.io/snapshot.ref" in preparing, snapshotter
-	// author will know it is for pulling image. It will be useful.
-	//
-	// The label is only propagated during pulling image. So, is it possible
-	// to propagate by image.Unpack()?
-	labelKeyTargetSnapshotRef = "containerd.io/snapshot.ref"
-
-	// labelKeyImageRef is the label to mark where the snapshot comes from.
-	//
-	// TODO(fuweid): Is it possible to use it in upstream?
-	labelKeyImageRef = "containerd.io/snapshot/image-ref"
-
-	// labelKeyOverlayBDBlobDigest is the annotation key in the manifest to
-	// describe the digest of blob in OverlayBD format.
-	//
-	// NOTE: The annotation is part of image layer blob's descriptor.
-	labelKeyOverlayBDBlobDigest = "containerd.io/snapshot/overlaybd/blob-digest"
-
-	// labelKeyOverlayBDBlobSize is the annotation key in the manifest to
-	// describe the size of blob in OverlayBD format.
-	//
-	// NOTE: The annotation is part of image layer blob's descriptor.
-	labelKeyOverlayBDBlobSize = "containerd.io/snapshot/overlaybd/blob-size"
-
-	// labelKeyOverlayBDBlobFsType is the annotation key in the manifest to
-	// describe the filesystem type to be mounted as of blob in OverlayBD format.
-	//
-	// NOTE: The annotation is part of image layer blob's descriptor.
-	labelKeyOverlayBDBlobFsType = "containerd.io/snapshot/overlaybd/blob-fs-type"
-
-	// labelKeyAccelerationLayer is the annotation key in the manifest to indicate
-	// whether a top layer is acceleration layer or not.
-	labelKeyAccelerationLayer = "containerd.io/snapshot/overlaybd/acceleration-layer"
-
-	// labelKeyRecordTrace tells snapshotter to record trace
-	labelKeyRecordTrace = "containerd.io/snapshot/overlaybd/record-trace"
-
-	// labelKeyRecordTracePath is the the file path to record trace
-	labelKeyRecordTracePath = "containerd.io/snapshot/overlaybd/record-trace-path"
-
-	// labelKeyZFileConfig is the config of ZFile
-	labelKeyZFileConfig = "containerd.io/snapshot/overlaybd/zfile-config"
-
-	// labelKeyCriImageRef is thr image-ref from cri
-	labelKeyCriImageRef = "containerd.io/snapshot/cri.image-ref"
-
-	// labelKeyFastOCIImageRef is the index annotation key for image layer digest
-	labelKeyFastOCIDigest = "containerd.io/snapshot/overlaybd/fastoci/target-digest"
-
-	// labelKeyFastOCIMediaType is the index annotation key for image layer media type
-	labelKeyFastOCIMediaType = "containerd.io/snapshot/overlaybd/fastoci/target-media-type"
-
-	remoteLabel    = "containerd.io/snapshot/remote"
-	remoteLabelVal = "remote snapshot"
-)
-
-// interface
-const (
-	// LabelSupportReadWriteMode is used to support writable block device
-	// for active snapshotter.
-	//
-	// By default, multiple active snapshotters can share one block device
-	// from parent snapshotter(committed). Like image builder and
-	// sandboxed-like container runtime(KataContainer, Firecracker), those
-	// cases want to use the block device alone or as writable.
-	// There are two ways to provide writable devices:
-	//  - 'dir' mark the snapshotter
-	//    as wriable block device and mount it on rootfs.
-	//  - 'dev' mark the snapshotter
-	//    as wriable block device without mount.
-	LabelSupportReadWriteMode = "containerd.io/snapshot/overlaybd.writable"
-
-	// LabelLocalOverlayBDPath is used to export the commit file path.
-	//
-	// NOTE: Only used in image build.
-	LabelLocalOverlayBDPath = "containerd.io/snapshot/overlaybd.localcommitpath"
 )
 
 const (
@@ -403,7 +315,7 @@ func (o *snapshotter) getWritableType(ctx context.Context, id string, info snaps
 		}
 		return roDir
 	}
-	m, ok := info.Labels[LabelSupportReadWriteMode]
+	m, ok := info.Labels[label.SupportReadWriteMode]
 	if !ok {
 		return rwMode(o.rwMode)
 	}
@@ -460,11 +372,11 @@ func (o *snapshotter) createMountPoint(ctx context.Context, kind snapshots.Kind,
 	// If the layer is in overlaybd format, construct backstore spec and saved it into snapshot dir.
 	// Return ErrAlreadyExists to skip pulling and unpacking layer. See https://github.com/containerd/containerd/blob/master/docs/remote-snapshotter.md#snapshotter-apis-for-querying-remote-snapshots
 	// This part code is only for Pull.
-	if targetRef, ok := info.Labels[labelKeyTargetSnapshotRef]; ok {
+	if targetRef, ok := info.Labels[label.TargetSnapshotRef]; ok {
 
 		// Acceleration layer will not use remote snapshot. It still needs containerd to pull,
 		// unpack blob and commit snapshot. So return a normal mount point here.
-		isAccelLayer := info.Labels[labelKeyAccelerationLayer]
+		isAccelLayer := info.Labels[label.AccelerationLayer]
 		log.G(ctx).Debugf("Prepare (targetRefLabel: %s, accelLayerLabel: %s)", targetRef, isAccelLayer)
 		if isAccelLayer == "yes" {
 			if err := o.constructSpecForAccelLayer(id, parentID); err != nil {
@@ -489,7 +401,7 @@ func (o *snapshotter) createMountPoint(ctx context.Context, kind snapshots.Kind,
 		if err != nil {
 			return nil, err
 		}
-		if _, isFastOCI := info.Labels[labelKeyFastOCIDigest]; isFastOCI {
+		if _, isFastOCI := info.Labels[label.FastOCIDigest]; isFastOCI {
 			log.G(ctx).Debugf("%s is FastOCI layer", s.ID)
 			if err := o.constructOverlayBDSpec(ctx, key, false); err != nil {
 				return nil, err
@@ -497,7 +409,7 @@ func (o *snapshotter) createMountPoint(ctx context.Context, kind snapshots.Kind,
 			stype = storageTypeNormal
 		}
 		if stype == storageTypeRemoteBlock {
-			info.Labels[remoteLabel] = remoteLabelVal // Mark this snapshot as remote
+			info.Labels[label.RemoteLabel] = label.RemoteLabelVal // Mark this snapshot as remote
 			if _, _, err = o.commit(ctx, targetRef, key,
 				append(opts, snapshots.WithLabels(info.Labels))...); err != nil {
 				return nil, err
@@ -519,7 +431,7 @@ func (o *snapshotter) createMountPoint(ctx context.Context, kind snapshots.Kind,
 	writeType := o.getWritableType(ctx, parentID, info)
 
 	// If Preparing for rootfs, find metadata from its parent (top layer), launch and mount backstore device.
-	if _, ok := info.Labels[labelKeyTargetSnapshotRef]; !ok {
+	if _, ok := info.Labels[label.TargetSnapshotRef]; !ok {
 		log.G(ctx).Infof("Preparing rootfs. writeType: %s", writeType)
 		if writeType != roDir {
 			stype = storageTypeLocalBlock
@@ -536,9 +448,9 @@ func (o *snapshotter) createMountPoint(ctx context.Context, kind snapshots.Kind,
 		switch stype {
 		case storageTypeLocalBlock, storageTypeRemoteBlock:
 			if parent != "" {
-				parentIsAccelLayer := parentInfo.Labels[labelKeyAccelerationLayer] == "yes"
-				needRecordTrace := info.Labels[labelKeyRecordTrace] == "yes"
-				recordTracePath := info.Labels[labelKeyRecordTracePath]
+				parentIsAccelLayer := parentInfo.Labels[label.AccelerationLayer] == "yes"
+				needRecordTrace := info.Labels[label.RecordTrace] == "yes"
+				recordTracePath := info.Labels[label.RecordTracePath]
 				log.G(ctx).Debugf("Prepare rootfs (parentIsAccelLayer: %t, needRecordTrace: %t, recordTracePath: %s)",
 					parentIsAccelLayer, needRecordTrace, recordTracePath)
 
@@ -570,7 +482,7 @@ func (o *snapshotter) createMountPoint(ctx context.Context, kind snapshots.Kind,
 				obdID = parentID
 				obdInfo = &parentInfo
 			}
-			fsType, ok := obdInfo.Labels[labelKeyOverlayBDBlobFsType]
+			fsType, ok := obdInfo.Labels[label.OverlayBDBlobFsType]
 			if !ok {
 				log.G(ctx).Warnf("cannot get fs type from label, %v", obdInfo.Labels)
 				fsType = "ext4"
@@ -696,7 +608,7 @@ func (o *snapshotter) Mounts(ctx context.Context, key string) (_ []mount.Mount, 
 		}
 
 		if parentStype == storageTypeRemoteBlock || parentStype == storageTypeLocalBlock {
-			fsType, ok := parentInfo.Labels[labelKeyOverlayBDBlobFsType]
+			fsType, ok := parentInfo.Labels[label.OverlayBDBlobFsType]
 			if !ok {
 				fsType = "ext4"
 			}
@@ -741,9 +653,9 @@ func (o *snapshotter) Commit(ctx context.Context, name, key string, opts ...snap
 	}
 
 	// if writable, should commit the data and make it immutable.
-	if _, writableBD := oinfo.Labels[LabelSupportReadWriteMode]; writableBD {
+	if _, writableBD := oinfo.Labels[label.SupportReadWriteMode]; writableBD {
 		// TODO(fuweid): how to rollback?
-		if oinfo.Labels[labelKeyAccelerationLayer] == "yes" {
+		if oinfo.Labels[label.AccelerationLayer] == "yes" {
 			log.G(ctx).Info("Commit accel-layer requires no writable_data")
 		} else {
 			if err := o.unmountAndDetachBlockDevice(ctx, id, key); err != nil {
@@ -751,7 +663,7 @@ func (o *snapshotter) Commit(ctx context.Context, name, key string, opts ...snap
 			}
 
 			var zfileCfg ZFileConfig
-			if cfgStr, ok := oinfo.Labels[labelKeyZFileConfig]; ok {
+			if cfgStr, ok := oinfo.Labels[label.ZFileConfig]; ok {
 				if err := json.Unmarshal([]byte(cfgStr), &zfileCfg); err != nil {
 					return err
 				}
@@ -771,7 +683,7 @@ func (o *snapshotter) Commit(ctx context.Context, name, key string, opts ...snap
 				os.Remove(o.overlaybdWritableIndexPath(id))
 			}()
 
-			opts = append(opts, snapshots.WithLabels(map[string]string{LabelLocalOverlayBDPath: o.magicFilePath(id)}))
+			opts = append(opts, snapshots.WithLabels(map[string]string{label.LocalOverlayBDPath: o.magicFilePath(id)}))
 		}
 	}
 
@@ -796,8 +708,8 @@ func (o *snapshotter) Commit(ctx context.Context, name, key string, opts ...snap
 			info.Labels = make(map[string]string)
 		}
 
-		info.Labels[LabelLocalOverlayBDPath] = o.magicFilePath(id)
-		info, err = storage.UpdateInfo(ctx, info, fmt.Sprintf("labels.%s", LabelLocalOverlayBDPath))
+		info.Labels[label.LocalOverlayBDPath] = o.magicFilePath(id)
+		info, err = storage.UpdateInfo(ctx, info, fmt.Sprintf("labels.%s", label.LocalOverlayBDPath))
 		if err != nil {
 			return err
 		}
@@ -1160,11 +1072,11 @@ func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 }
 
 func (o *snapshotter) identifySnapshotStorageType(ctx context.Context, id string, info snapshots.Info) (storageType, error) {
-	if _, ok := info.Labels[labelKeyTargetSnapshotRef]; ok {
-		_, hasBDBlobSize := info.Labels[labelKeyOverlayBDBlobSize]
-		_, hasBDBlobDigest := info.Labels[labelKeyOverlayBDBlobDigest]
-		_, hasRef := info.Labels[labelKeyImageRef]
-		_, hasCriRef := info.Labels[labelKeyCriImageRef]
+	if _, ok := info.Labels[label.TargetSnapshotRef]; ok {
+		_, hasBDBlobSize := info.Labels[label.OverlayBDBlobSize]
+		_, hasBDBlobDigest := info.Labels[label.OverlayBDBlobDigest]
+		_, hasRef := info.Labels[label.TargetImageRef]
+		_, hasCriRef := info.Labels[label.CRIImageRef]
 
 		if hasBDBlobSize && hasBDBlobDigest {
 			if hasRef || hasCriRef {

--- a/pkg/snapshot/storage.go
+++ b/pkg/snapshot/storage.go
@@ -31,6 +31,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containerd/accelerated-container-image/pkg/label"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
@@ -508,15 +509,15 @@ func (o *snapshotter) constructOverlayBDSpec(ctx context.Context, key string, wr
 			return errors.Errorf("remote block device is readonly, not support writable")
 		}
 
-		blobSize, err := strconv.Atoi(info.Labels[labelKeyOverlayBDBlobSize])
+		blobSize, err := strconv.Atoi(info.Labels[label.OverlayBDBlobSize])
 		if err != nil {
-			return errors.Wrapf(err, "failed to parse value of label %s of snapshot %s", labelKeyOverlayBDBlobSize, key)
+			return errors.Wrapf(err, "failed to parse value of label %s of snapshot %s", label.OverlayBDBlobSize, key)
 		}
 
-		blobDigest := info.Labels[labelKeyOverlayBDBlobDigest]
-		ref, hasRef := info.Labels[labelKeyImageRef]
+		blobDigest := info.Labels[label.OverlayBDBlobDigest]
+		ref, hasRef := info.Labels[label.TargetImageRef]
 		if !hasRef {
-			criRef, hasCriRef := info.Labels[labelKeyCriImageRef]
+			criRef, hasCriRef := info.Labels[label.CRIImageRef]
 			if !hasCriRef {
 				return errors.Errorf("no image-ref label")
 			}
@@ -529,13 +530,13 @@ func (o *snapshotter) constructOverlayBDSpec(ctx context.Context, key string, wr
 		}
 
 		configJSON.RepoBlobURL = blobPrefixURL
-		if dataDgst, isFastOCI := info.Labels[labelKeyFastOCIDigest]; isFastOCI {
+		if dataDgst, isFastOCI := info.Labels[label.FastOCIDigest]; isFastOCI {
 			lower := OverlayBDBSConfigLower{
 				Dir:          o.upperPath(id),
 				File:         o.fastociFsMeta(id),
 				TargetDigest: dataDgst,
 			}
-			if isGzipLayerType(info.Labels[labelKeyFastOCIMediaType]) {
+			if isGzipLayerType(info.Labels[label.FastOCIMediaType]) {
 				lower.GzipIndex = o.fastociGzipIndex(id)
 			}
 			configJSON.Lowers = append(configJSON.Lowers, lower)

--- a/pkg/snapshot/storage.go
+++ b/pkg/snapshot/storage.go
@@ -31,6 +31,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/reference"
@@ -38,6 +39,7 @@ import (
 	"github.com/containerd/containerd/snapshots/storage"
 	"github.com/containerd/continuity"
 	"github.com/moby/sys/mountinfo"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
@@ -72,15 +74,20 @@ type OverlayBDBSConfig struct {
 
 // OverlayBDBSConfigLower
 type OverlayBDBSConfigLower struct {
-	File   string `json:"file,omitempty"`
-	Digest string `json:"digest,omitempty"`
-	Size   int64  `json:"size,omitempty"`
-	Dir    string `json:"dir,omitempty"`
+	GzipIndex    string `json:"gzipIndex,omitempty"`
+	File         string `json:"file,omitempty"`
+	Digest       string `json:"digest,omitempty"`
+	TargetFile   string `json:"targetFile,omitempty"`
+	TargetDigest string `json:"targetDigest,omitempty"`
+	Size         int64  `json:"size,omitempty"`
+	Dir          string `json:"dir,omitempty"`
 }
 
 type OverlayBDBSConfigUpper struct {
-	Index string `json:"index,omitempty"`
-	Data  string `json:"data,omitempty"`
+	Index     string `json:"index,omitempty"`
+	Data      string `json:"data,omitempty"`
+	Target    string `json:"target,omitempty"`
+	GzipIndex string `json:"gzipIndex,omitempty"`
 }
 
 func (o *snapshotter) checkOverlaybdInUse(ctx context.Context, dir string) (bool, error) {
@@ -522,11 +529,23 @@ func (o *snapshotter) constructOverlayBDSpec(ctx context.Context, key string, wr
 		}
 
 		configJSON.RepoBlobURL = blobPrefixURL
-		configJSON.Lowers = append(configJSON.Lowers, OverlayBDBSConfigLower{
-			Digest: blobDigest,
-			Size:   int64(blobSize),
-			Dir:    o.upperPath(id),
-		})
+		if dataDgst, isFastOCI := info.Labels[labelKeyFastOCIDigest]; isFastOCI {
+			lower := OverlayBDBSConfigLower{
+				Dir:          o.upperPath(id),
+				File:         o.fastociFsMeta(id),
+				TargetDigest: dataDgst,
+			}
+			if isGzipLayerType(info.Labels[labelKeyFastOCIMediaType]) {
+				lower.GzipIndex = o.fastociGzipIndex(id)
+			}
+			configJSON.Lowers = append(configJSON.Lowers, lower)
+		} else {
+			configJSON.Lowers = append(configJSON.Lowers, OverlayBDBSConfigLower{
+				Digest: blobDigest,
+				Size:   int64(blobSize),
+				Dir:    o.upperPath(id),
+			})
+		}
 
 	case storageTypeLocalBlock:
 		if writable {
@@ -710,4 +729,8 @@ func lookup(dir string) error {
 		return errors.Errorf("failed to find the mount info for %q", dir)
 	}
 	return nil
+}
+
+func isGzipLayerType(mediaType string) bool {
+	return mediaType == specs.MediaTypeImageLayerGzip || mediaType == images.MediaTypeDockerSchema2LayerGzip
 }


### PR DESCRIPTION
# Overview
FastOCI is a new image format based on OverlayBD, it enables standard OCI images to be lazily loaded by building a small index that is 3% size of the OCI image.

FastOCI is compatible with OverlayBD format. You can use FastOCI in much the same way as you used OverlayBD.

We will provide more information in later documents soon.

# Usage
### Build
```
# backward compatibility: old usage still work, which will build overlaybd
bin/convertor -r <repo> -i <input-tag> -o <overlaybd-tag>

# build fastoci
bin/convertor -r <repo> -i <input-tag> --fastoci <fastoci-tag>

# build overlaybd
bin/convertor -r <repo> -i <input-tag> --overlaybd <overlaybd-tag>

# build both fastoci and overlaybd in one task
bin/convertor -r <repo> -i <input-tag> --fastoci <fastoci-tag> --overlaybd <overlaybd-tag>
```
###  Pull and Run
In the same way as using OverlayBD