### PR TITLE
Support overlaybd layer deduplication in userspace convertor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bin/
+.vscode

--- a/cmd/convertor/builder/builder_engine.go
+++ b/cmd/convertor/builder/builder_engine.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/containerd/accelerated-container-image/cmd/convertor/database"
 	"github.com/containerd/containerd/archive/compression"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/remotes"
@@ -48,17 +49,30 @@ type builderEngine interface {
 	// UploadImage upload new manifest and config
 	UploadImage(ctx context.Context) error
 
-	// cleanup remove workdir
+	// deduplication functions
+	// finds already converted layer in db and validates presence in registry
+	CheckForConvertedLayer(ctx context.Context, idx int, chainID string) (*specs.Descriptor, error)
+
+	// downloads the already converted layer
+	DownloadConvertedLayer(ctx context.Context, idx int, desc *specs.Descriptor) error
+
+	// store chainID -> converted layer mapping for deduplication
+	StoreConvertedLayerDetails(ctx context.Context, chainID string, idx int) error
+
+	// Cleanup removes workdir
 	Cleanup()
 }
 
 type builderEngineBase struct {
-	fetcher  remotes.Fetcher
-	pusher   remotes.Pusher
-	manifest specs.Manifest
-	config   specs.Image
-	workDir  string
-	oci      bool
+	fetcher    remotes.Fetcher
+	pusher     remotes.Pusher
+	manifest   specs.Manifest
+	config     specs.Image
+	workDir    string
+	oci        bool
+	db         database.ConversionDatabase
+	host       string
+	repository string
 }
 
 func (e *builderEngineBase) isGzipLayer(ctx context.Context, idx int) (bool, error) {

--- a/cmd/convertor/builder/builder_engine.go
+++ b/cmd/convertor/builder/builder_engine.go
@@ -51,13 +51,13 @@ type builderEngine interface {
 
 	// deduplication functions
 	// finds already converted layer in db and validates presence in registry
-	CheckForConvertedLayer(ctx context.Context, idx int, chainID string) (*specs.Descriptor, error)
+	CheckForConvertedLayer(ctx context.Context, idx int) (specs.Descriptor, error)
 
 	// downloads the already converted layer
-	DownloadConvertedLayer(ctx context.Context, idx int, desc *specs.Descriptor) error
+	DownloadConvertedLayer(ctx context.Context, idx int, desc specs.Descriptor) error
 
 	// store chainID -> converted layer mapping for deduplication
-	StoreConvertedLayerDetails(ctx context.Context, chainID string, idx int) error
+	StoreConvertedLayerDetails(ctx context.Context, idx int) error
 
 	// Cleanup removes workdir
 	Cleanup()

--- a/cmd/convertor/builder/fastoci_builder.go
+++ b/cmd/convertor/builder/fastoci_builder.go
@@ -188,18 +188,21 @@ func (e *fastOCIBuilderEngine) UploadImage(ctx context.Context) error {
 	return e.uploadManifestAndConfig(ctx)
 }
 
+// Layer deduplication in FastOCI is not currently supported due to conversion not
+// being reproducible at the moment which can lead to occasional bugs.
+
 // CheckForConvertedLayer TODO
-func (e *fastOCIBuilderEngine) CheckForConvertedLayer(ctx context.Context, idx int, chainID string) (*specs.Descriptor, error) {
-	return nil, errdefs.ErrNotFound
+func (e *fastOCIBuilderEngine) CheckForConvertedLayer(ctx context.Context, idx int) (specs.Descriptor, error) {
+	return specs.Descriptor{}, errdefs.ErrNotFound
 }
 
 // StoreConvertedLayerDetails TODO
-func (e *fastOCIBuilderEngine) StoreConvertedLayerDetails(ctx context.Context, chainID string, idx int) error {
+func (e *fastOCIBuilderEngine) StoreConvertedLayerDetails(ctx context.Context, idx int) error {
 	return nil
 }
 
 // DownloadConvertedLayer TODO
-func (e *fastOCIBuilderEngine) DownloadConvertedLayer(ctx context.Context, idx int, desc *specs.Descriptor) error {
+func (e *fastOCIBuilderEngine) DownloadConvertedLayer(ctx context.Context, idx int, desc specs.Descriptor) error {
 	return errdefs.ErrNotImplemented
 }
 

--- a/cmd/convertor/builder/fastoci_builder.go
+++ b/cmd/convertor/builder/fastoci_builder.go
@@ -27,6 +27,7 @@ import (
 	"github.com/containerd/accelerated-container-image/pkg/label"
 	"github.com/containerd/accelerated-container-image/pkg/snapshot"
 	"github.com/containerd/containerd/archive/compression"
+	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	"github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -185,6 +186,21 @@ func (e *fastOCIBuilderEngine) UploadImage(ctx context.Context) error {
 	e.manifest.Layers = append([]specs.Descriptor{baseDesc}, e.manifest.Layers...)
 	e.config.RootFS.DiffIDs = append([]digest.Digest{baseDesc.Digest}, e.config.RootFS.DiffIDs...)
 	return e.uploadManifestAndConfig(ctx)
+}
+
+// CheckForConvertedLayer TODO
+func (e *fastOCIBuilderEngine) CheckForConvertedLayer(ctx context.Context, idx int, chainID string) (*specs.Descriptor, error) {
+	return nil, errdefs.ErrNotFound
+}
+
+// StoreConvertedLayerDetails TODO
+func (e *fastOCIBuilderEngine) StoreConvertedLayerDetails(ctx context.Context, chainID string, idx int) error {
+	return nil
+}
+
+// DownloadConvertedLayer TODO
+func (e *fastOCIBuilderEngine) DownloadConvertedLayer(ctx context.Context, idx int, desc *specs.Descriptor) error {
+	return errdefs.ErrNotImplemented
 }
 
 func (e *fastOCIBuilderEngine) Cleanup() {

--- a/cmd/convertor/database/database.go
+++ b/cmd/convertor/database/database.go
@@ -1,0 +1,38 @@
+/*
+   Copyright The Accelerated Container Image Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package database
+
+import (
+	"context"
+
+	"github.com/opencontainers/go-digest"
+)
+
+type ConversionDatabase interface {
+	GetEntryForRepo(ctx context.Context, host string, repository string, chainID string) *Entry
+	GetCrossRepoEntries(ctx context.Context, host string, chainID string) []*Entry
+	CreateEntry(ctx context.Context, host string, repository string, convertedDigest digest.Digest, chainID string, size int64) error
+	DeleteEntry(ctx context.Context, host string, repository string, chainID string) error
+}
+
+type Entry struct {
+	ConvertedDigest digest.Digest
+	DataSize        int64
+	Repository      string
+	ChainID         string
+	Host            string
+}

--- a/cmd/convertor/database/mysql.go
+++ b/cmd/convertor/database/mysql.go
@@ -1,0 +1,83 @@
+/*
+   Copyright The Accelerated Container Image Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package database
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/containerd/containerd/log"
+	"github.com/pkg/errors"
+
+	"github.com/opencontainers/go-digest"
+)
+
+type sqldb struct {
+	db *sql.DB
+}
+
+func NewSqlDB(db *sql.DB) ConversionDatabase {
+	return &sqldb{
+		db: db,
+	}
+}
+
+func (m *sqldb) GetEntryForRepo(ctx context.Context, host string, repository string, chainID string) *Entry {
+	var entry Entry
+
+	row := m.db.QueryRowContext(ctx, "select host, repo, chain_id, data_digest, data_size from overlaybd_layers where host=? and repo=? and chain_id=?", host, repository, chainID)
+	if err := row.Scan(&entry.Host, &entry.Repository, &entry.ChainID, &entry.ConvertedDigest, &entry.DataSize); err != nil {
+		return nil
+	}
+
+	return &entry
+}
+
+func (m *sqldb) GetCrossRepoEntries(ctx context.Context, host string, chainID string) []*Entry {
+	rows, err := m.db.QueryContext(ctx, "select host, repo, chain_id, data_digest, data_size from overlaybd_layers where host=? and chain_id=?", host, chainID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil
+		}
+		log.G(ctx).Infof("query error %v", err)
+		return nil
+	}
+	var entries []*Entry
+	for rows.Next() {
+		var entry Entry
+		err = rows.Scan(&entry.Host, &entry.Repository, &entry.ChainID, &entry.ConvertedDigest, &entry.DataSize)
+		if err != nil {
+			continue
+		}
+		entries = append(entries, &entry)
+	}
+
+	return entries
+}
+
+func (m *sqldb) CreateEntry(ctx context.Context, host string, repository string, convertedDigest digest.Digest, chainID string, size int64) error {
+	_, err := m.db.ExecContext(ctx, "insert into overlaybd_layers(host, repo, chain_id, data_digest, data_size) values(?, ?, ?, ?, ?)", host, repository, chainID, convertedDigest, size)
+	return err
+}
+
+func (m *sqldb) DeleteEntry(ctx context.Context, host string, repository string, chainID string) error {
+	_, err := m.db.Exec("delete from overlaybd_layers where host=? and repo=? and chain_id=?", host, repository, chainID)
+	if err != nil {
+		return errors.Wrapf(err, "failed to remove invalid record in db")
+	}
+	return nil
+}


### PR DESCRIPTION
This PR introduces the ability to deduplicate overlyabd layers that have already been converted. This is done by using a database to store the chainID-> converted layer mapping. If a chainID is recognized and the layer can be found or mounted to the registry we download the converted layer, this layer can then be used by subsequent steps to build the full converted image. This functionality and the mysql database info included is based on the original pkg/convertor.go

Tested Functionality:
 - Conversion works with or without enabling the db flags
 - Conversion succeeds with any number of layers found to already be converted
 - Image output with or without database deduplication is the same.
 - Image output is consistent with pre database code introduction
 - Cross Repo Mount works as expected
  
 Limitations:
 - This PR does not include deduplication for fast_OCI, though I assume the leftover interfaces can be reused for that purpose similarly. This is because experimentally fastOCI manifests always seem to end up with different digests for its layers, so I had trouble validating the output for it and choose to not include it for this PR and relegate that for a future PR.
 - I tested much of this manually as emulating the e2e is not trivial but I recognize more tests such as unit tests or integration tests might be ideal in the future.
 