### PR TITLE
[Bugfix] do not panic when image has index layer

### DIFF
--- a/cmd/convertor/builder/builder_engine.go
+++ b/cmd/convertor/builder/builder_engine.go
@@ -167,7 +167,7 @@ func getBuilderEngineBase(ctx context.Context, resolver remotes.Resolver, ref, t
 	return &builderEngineBase{
 		fetcher:  fetcher,
 		pusher:   pusher,
-		manifest: manifest,
-		config:   config,
+		manifest: *manifest,
+		config:   *config,
 	}, nil
 }


### PR DESCRIPTION
1. reorganize download workflow to avoid panicing when image has index layer
2. extend platformMatcher in the future if multi-arch is required in the future
3. TODO: url in descriptor is ignored for now, need to be accomodated