### PR TITLE
Add maintainer list.

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,14 @@
+# accelerated-container-image maintainers
+#
+# As a containerd sub-project, containerd maintainers are also included from https://github.com/containerd/project/blob/main/MAINTAINERS.
+# See https://github.com/containerd/project/blob/main/GOVERNANCE.md for description of maintainer role
+#
+# COMMITTERS
+# GitHub ID, Name, Email address
+"liulanzheng", "Lanzheng Liu", "lanzheng.liulz@alibaba-inc.com"
+"bigvan", "Yifan Yuan", "tuji.yyf@alibaba-inc.com"
+"yuchen0cc", "yuchen.cc", "yuchen.cc@alibaba-inc.com"
+
+# REVIEWERS
+# GitHub ID, Name, Email address
+"estebanreyl", "Esteban Rey", "esrey@microsoft.com"


### PR DESCRIPTION
Hi guys~  
These developers have contributed lots of code and proposals to this project. I would like to invite them as project maintainers:
  - invite @estebanreyl as a reviewer.
  - invite @yuchen0cc as a committer

Needs explicit LGTM from @estebanreyl @yuchen0cc and 1/3 of the **'acelerated-container-image'** Committers.
according to https://github.com/containerd/project/blob/main/GOVERNANCE.md :

> After a candidate has been informally proposed in the maintainers forum, the
  existing maintainers are given seven days to discuss the candidate, raise
  objections and show their support. Formal voting takes place on a pull request
  that adds the contributor to the MAINTAINERS file. Candidates must be approved
  by 2/3 of the current committers by adding their approval or LGTM to the pull
  request. The reviewer role has the same process but only requires 1/3 of current
  committers.
>
>  If a candidate is approved, they will be invited to add their own LGTM or
  approval to the pull request to acknowledge their agreement. A committer will
  verify the numbers of votes that have been received and the allotted seven days
  have passed, then merge the pull request and invite the contributor to the
  organization.
>
> For non-core sub-projects, only committers of the repository that the candidate
is proposed for are given votes.

- [x] @BigVan 
- [x] @fuweid 
- [x] @liulanzheng 

I'd also like to get a few LGTMs from the Core Committers too. (not necessary)
