### PR TITLE
Erase writable label in Prepare if not overlaybd

### DIFF
--- a/pkg/snapshot/overlay.go
+++ b/pkg/snapshot/overlay.go
@@ -527,6 +527,11 @@ func (o *snapshotter) createMountPoint(ctx context.Context, kind snapshots.Kind,
 			// do nothing
 		}
 	}
+	if _, writableBD := info.Labels[label.SupportReadWriteMode]; stype == storageTypeNormal && writableBD {
+		// if is not overlaybd writable layer, delete label before commit
+		delete(info.Labels, label.SupportReadWriteMode)
+		storage.UpdateInfo(ctx, info)
+	}
 
 	rollback = false
 	if err := t.Commit(); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
In buildkit build, we will add `containerd.io/snapshot/overlaybd.writable=dev` when `--oci-worker-snapshotter=overlaybd`. For compatibility, we should delete this label in Prepare for OCI image, or else it will lead to an error.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/accelerated-container-image/blob/main/MAINTAINERS. -->
