### PR TITLE
expose const of writable layer

### DIFF
--- a/pkg/snapshot/storage.go
+++ b/pkg/snapshot/storage.go
@@ -192,7 +192,7 @@ func (o *snapshotter) unmountAndDetachBlockDevice(ctx context.Context, snID stri
 	if err != nil {
 		log.G(ctx).Errorf("read device name failed: %s, err: %v", o.overlaybdBackstoreMarkFile(snID), err)
 	}
-	if writeType != rwDev {
+	if writeType != RwDev {
 		mountPoint := o.overlaybdMountpoint(snID)
 		log.G(ctx).Debugf("check overlaybd mountpoint is in use: %s", mountPoint)
 		busy, err := o.checkOverlaybdInUse(ctx, mountPoint)
@@ -394,7 +394,7 @@ func (o *snapshotter) attachAndMountBlockDevice(ctx context.Context, snID string
 			}
 
 			var mflag uintptr = unix.MS_RDONLY
-			if writable != roDir {
+			if writable != RoDir {
 				mflag = 0
 			}
 
@@ -426,7 +426,7 @@ func (o *snapshotter) attachAndMountBlockDevice(ctx context.Context, snID string
 				}
 			}
 
-			if writable != rwDev {
+			if writable != RwDev {
 				if fstype != "ntfs" {
 					log.G(ctx).Infof("fs type: %s, mount options: %s, rw: %s", fstype, data, writable)
 					//if err := unix.Mount(device, mountPoint, "ext4", mflag, "discard"); err != nil {
@@ -444,7 +444,7 @@ func (o *snapshotter) attachAndMountBlockDevice(ctx context.Context, snID string
 					}
 				} else {
 					args := []string{"-t", fstype}
-					if writable == roDir {
+					if writable == RoDir {
 						args = append(args, "-r")
 					}
 					if data != "" {


### PR DESCRIPTION
**What this PR does / why we need it**:
We should expose the const value of the writable layer type to maintain consistency and reduce invasive modifications in other projects that import this package (like buildkit.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/accelerated-container-image/blob/main/MAINTAINERS. -->
