### PR TITLE
fix bug of filename mismatch in fastoci conversion

### DIFF
--- a/cmd/convertor/builder/fastoci_builder.go
+++ b/cmd/convertor/builder/fastoci_builder.go
@@ -244,5 +244,8 @@ func (e *fastOCIBuilderEngine) apply(ctx context.Context, dir string) error {
 }
 
 func (e *fastOCIBuilderEngine) commit(ctx context.Context, dir string) error {
-	return utils.Commit(ctx, dir, dir, false, "-z", "--fastoci")
+	if err := utils.Commit(ctx, dir, dir, false, "-z", "--fastoci"); err != nil {
+		return err
+	}
+	return os.Rename(path.Join(dir, commitFile), path.Join(dir, fsMetaFile))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
In fastoci conversion, we need a `ext4.fs.meta` after `overlaybd-commit`, but after [this commit](https://github.com/containerd/accelerated-container-image/commit/b205f2c08db16713c107685c935bf46a39d39349), it will become `overlaybd.commit` and make conversion failed.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/accelerated-container-image/blob/main/MAINTAINERS. -->
