### PR TITLE
Add overlaybd version number to image-convertor

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,15 @@ Accelerated Container Image is a __non-core__ sub-project of containerd.
 
 * Welcome to contribute! [CONTRIBUTING](docs/CONTRIBUTING.md)
 
+## Release Version Support
+
+There will be an annotation `containerd.io/snapshot/overlaybd/version` in the manifest of the converted image to specify the format version, following is the
+overlaybd release version required by them.
+
+* `0.1.0`: for now, all release versions of overlaybd support this.
+
+* `0.1.0-fastoci`: overlaybd >= v0.6.10
+
 ## Overview
 
 With OCI image spec, an image layer blob is saved as a tarball on the registry, describing the [changeset](https://github.com/opencontainers/image-spec/blob/v1.0.1/layer.md#change-types) based on it's previous layer. However, tarball is not designed to be seekable and random access is not supported. Complete downloading of all blobs is always necessary before bringing up a container.

--- a/cmd/convertor/builder/fastoci_builder.go
+++ b/cmd/convertor/builder/fastoci_builder.go
@@ -27,6 +27,7 @@ import (
 	"github.com/containerd/accelerated-container-image/pkg/label"
 	"github.com/containerd/accelerated-container-image/pkg/snapshot"
 	"github.com/containerd/accelerated-container-image/pkg/utils"
+	"github.com/containerd/accelerated-container-image/pkg/version"
 	"github.com/containerd/containerd/archive/compression"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
@@ -136,6 +137,7 @@ func (e *fastOCIBuilderEngine) UploadLayer(ctx context.Context, idx int) error {
 	}
 	desc.MediaType = e.mediaTypeImageLayerGzip()
 	desc.Annotations = map[string]string{
+		label.OverlayBDVersion:    version.FastOCIVersionNumber,
 		label.OverlayBDBlobDigest: desc.Digest.String(),
 		label.OverlayBDBlobSize:   fmt.Sprintf("%d", desc.Size),
 		label.FastOCIDigest:       e.manifest.Layers[idx].Digest.String(),
@@ -177,6 +179,7 @@ func (e *fastOCIBuilderEngine) UploadImage(ctx context.Context) error {
 		Digest:    "sha256:c3a417552a6cf9ffa959b541850bab7d7f08f4255425bf8b48c85f7b36b378d9",
 		Size:      4737695,
 		Annotations: map[string]string{
+			label.OverlayBDVersion:    version.OverlayBDVersionNumber,
 			label.OverlayBDBlobDigest: "sha256:c3a417552a6cf9ffa959b541850bab7d7f08f4255425bf8b48c85f7b36b378d9",
 			label.OverlayBDBlobSize:   "4737695",
 		},

--- a/cmd/convertor/builder/overlaybd_builder.go
+++ b/cmd/convertor/builder/overlaybd_builder.go
@@ -30,6 +30,7 @@ import (
 	"github.com/containerd/accelerated-container-image/pkg/label"
 	"github.com/containerd/accelerated-container-image/pkg/snapshot"
 	"github.com/containerd/accelerated-container-image/pkg/utils"
+	"github.com/containerd/accelerated-container-image/pkg/version"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
@@ -131,6 +132,7 @@ func (e *overlaybdBuilderEngine) UploadLayer(ctx context.Context, idx int) error
 	}
 	desc.MediaType = e.mediaTypeImageLayer()
 	desc.Annotations = map[string]string{
+		label.OverlayBDVersion:    version.OverlayBDVersionNumber,
 		label.OverlayBDBlobDigest: desc.Digest.String(),
 		label.OverlayBDBlobSize:   fmt.Sprintf("%d", desc.Size),
 	}
@@ -271,6 +273,7 @@ func (e *overlaybdBuilderEngine) uploadBaseLayer(ctx context.Context) (specs.Des
 		Digest:    digester.Digest(),
 		Size:      countWriter.c,
 		Annotations: map[string]string{
+			label.OverlayBDVersion:    version.OverlayBDVersionNumber,
 			label.OverlayBDBlobDigest: digester.Digest().String(),
 			label.OverlayBDBlobSize:   fmt.Sprintf("%d", countWriter.c),
 		},

--- a/pkg/convertor/convertor.go
+++ b/pkg/convertor/convertor.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/containerd/accelerated-container-image/pkg/label"
 	"github.com/containerd/accelerated-container-image/pkg/utils"
+	"github.com/containerd/accelerated-container-image/pkg/version"
 	"github.com/sirupsen/logrus"
 
 	"github.com/containerd/containerd"
@@ -163,6 +164,7 @@ func (loader *contentLoader) Load(ctx context.Context, cs content.Store) (l Laye
 			Digest:    digester.Digest(),
 			Size:      countWriter.c,
 			Annotations: map[string]string{
+				label.OverlayBDVersion:    version.OverlayBDVersionNumber,
 				label.OverlayBDBlobDigest: digester.Digest().String(),
 				label.OverlayBDBlobSize:   fmt.Sprintf("%d", countWriter.c),
 			},

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -84,6 +84,9 @@ const (
 
 	RemoteLabel    = "containerd.io/snapshot/remote"
 	RemoteLabelVal = "remote snapshot"
+
+	// OverlayBDVersion is the version number of overlaybd blob
+	OverlayBDVersion = "containerd.io/snapshot/overlaybd/version"
 )
 
 // used in filterAnnotationsForSave (https://github.com/moby/buildkit/blob/v0.11/cache/refs.go#L882)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,22 @@
+/*
+   Copyright The Accelerated Container Image Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package version
+
+const (
+	OverlayBDVersionNumber = "0.1.0"
+	FastOCIVersionNumber   = "0.1.0-fastoci"
+)


### PR DESCRIPTION
**What this PR does / why we need it**:
Add overlaybd version number to both `embedded image-convertor` and `standalone userspace image-convertor`. Format as following: 

```
"annotations": {
  "containerd.io/snapshot/overlaybd/version": "0.1.0" // for normal overlaybd-image
  "containerd.io/snapshot/overlaybd/version": "0.1.0-fastoci" // for fastOCI index
}
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #169 

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [x]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/accelerated-container-image/blob/main/MAINTAINERS. -->
