### PR TITLE
fix parent uuid lost in overlaybd_builder & auth error when colon in password

### DIFF
--- a/cmd/convertor/builder/builder.go
+++ b/cmd/convertor/builder/builder.go
@@ -54,11 +54,10 @@ type overlaybdBuilder struct {
 func NewOverlayBDBuilder(ctx context.Context, opt BuilderOptions) (Builder, error) {
 	resolver := docker.NewResolver(docker.ResolverOptions{
 		Credentials: func(s string) (string, string, error) {
-			if opt.Auth == "" {
-				return "", "", nil
+			if i := strings.IndexByte(opt.Auth, ':'); i > 0 {
+				return opt.Auth[0:i], opt.Auth[i+1:], nil
 			}
-			authSplit := strings.Split(opt.Auth, ":")
-			return authSplit[0], authSplit[1], nil
+			return "", "", nil
 		},
 		PlainHTTP: opt.PlainHTTP,
 	})

--- a/cmd/convertor/builder/overlaybd_builder.go
+++ b/cmd/convertor/builder/overlaybd_builder.go
@@ -312,8 +312,11 @@ func (e *overlaybdBuilderEngine) commit(ctx context.Context, dir string, idx int
 		parentUUID = ""
 	}
 	curUUID := chainIDtoUUID(e.overlaybdLayers[idx].chainID)
-
-	if err := utils.Commit(ctx, dir, dir, false, "-z", "-t", "--uuid", curUUID); err != nil {
+	opts := []string{"-z", "-t", "--uuid", curUUID}
+	if parentUUID != "" {
+		opts = append(opts, "--parent-uuid", parentUUID)
+	}
+	if err := utils.Commit(ctx, dir, dir, false, opts...); err != nil {
 		return err
 	}
 	logrus.Infof("layer %d committed, uuid: %s, parent uuid: %s", idx, curUUID, parentUUID)


### PR DESCRIPTION
**What this PR does / why we need it**:
- In [this commit](https://github.com/containerd/accelerated-container-image/commit/b205f2c08db16713c107685c935bf46a39d39349#diff-9be2d4437402ce708d9ed51073c8c8e3e9b9be58589ab53be44c5fa95d134ae8L333-L335), `parentUUID` is lost after change, now it fixed.
- When password has a colon, text after colon will be ignored (such as Temporary Token in Alibaba Container Registry).
- 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/accelerated-container-image/blob/main/MAINTAINERS. -->
