### PR TITLE
Exclude baselayer when using mkfs

### DIFF
--- a/cmd/convertor/builder/overlaybd_builder.go
+++ b/cmd/convertor/builder/overlaybd_builder.go
@@ -59,9 +59,12 @@ func NewOverlayBDBuilderEngine(base *builderEngineBase) builderEngine {
 		Lowers:     []snapshot.OverlayBDBSConfigLower{},
 		ResultFile: "",
 	}
-	config.Lowers = append(config.Lowers, snapshot.OverlayBDBSConfigLower{
-		File: overlaybdBaseLayer,
-	})
+	if !base.mkfs {
+		config.Lowers = append(config.Lowers, snapshot.OverlayBDBSConfigLower{
+			File: overlaybdBaseLayer,
+		})
+		logrus.Infof("using default baselayer")
+	}
 
 	overlaybdLayers := make([]overlaybdConvertResult, len(base.manifest.Layers))
 
@@ -295,6 +298,7 @@ func (e *overlaybdBuilderEngine) create(ctx context.Context, dir string, mkfs bo
 	opts := []string{"-s", "64"}
 	if mkfs {
 		opts = append(opts, "--mkfs")
+		logrus.Infof("mkfs for baselayer")
 	}
 	return utils.Create(ctx, dir, opts...)
 }

--- a/cmd/convertor/builder/turboOCI_builder.go
+++ b/cmd/convertor/builder/turboOCI_builder.go
@@ -32,6 +32,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -60,9 +61,12 @@ func NewTurboOCIBuilderEngine(base *builderEngineBase) builderEngine {
 		Lowers:     []snapshot.OverlayBDBSConfigLower{},
 		ResultFile: "",
 	}
-	config.Lowers = append(config.Lowers, snapshot.OverlayBDBSConfigLower{
-		File: overlaybdBaseLayer,
-	})
+	if !base.mkfs {
+		config.Lowers = append(config.Lowers, snapshot.OverlayBDBSConfigLower{
+			File: overlaybdBaseLayer,
+		})
+		logrus.Infof("using default baselayer")
+	}
 	return &turboOCIBuilderEngine{
 		builderEngineBase: base,
 		overlaybdConfig:   config,


### PR DESCRIPTION
**What this PR does / why we need it**:
If using `--mkfs` for userspace convertor, default baselayer should be excluded from lowers.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #224 

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/accelerated-container-image/blob/main/MAINTAINERS. -->
