### PR TITLE
Exclude baselayer when using mkfs (turboOCI)

### DIFF
--- a/cmd/convertor/builder/turboOCI_builder.go
+++ b/cmd/convertor/builder/turboOCI_builder.go
@@ -186,11 +186,13 @@ func (e *turboOCIBuilderEngine) UploadImage(ctx context.Context) error {
 			label.OverlayBDBlobSize:   "4737695",
 		},
 	}
-	if err := uploadBlob(ctx, e.pusher, overlaybdBaseLayer, baseDesc); err != nil {
-		return errors.Wrapf(err, "failed to upload baselayer %q", overlaybdBaseLayer)
+	if !e.mkfs {
+		if err := uploadBlob(ctx, e.pusher, overlaybdBaseLayer, baseDesc); err != nil {
+			return errors.Wrapf(err, "failed to upload baselayer %q", overlaybdBaseLayer)
+		}
+		e.manifest.Layers = append([]specs.Descriptor{baseDesc}, e.manifest.Layers...)
+		e.config.RootFS.DiffIDs = append([]digest.Digest{baseDesc.Digest}, e.config.RootFS.DiffIDs...)
 	}
-	e.manifest.Layers = append([]specs.Descriptor{baseDesc}, e.manifest.Layers...)
-	e.config.RootFS.DiffIDs = append([]digest.Digest{baseDesc.Digest}, e.config.RootFS.DiffIDs...)
 	return e.uploadManifestAndConfig(ctx)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
If using `--mkfs` for userspace convertor, default baselayer should be excluded from lowers. (TurboOCI)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/accelerated-container-image/blob/main/MAINTAINERS. -->
