### PR TITLE
fixes for usage and seal

### DIFF
--- a/pkg/snapshot/storage.go
+++ b/pkg/snapshot/storage.go
@@ -40,6 +40,7 @@ import (
 	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/containerd/snapshots/storage"
 	"github.com/containerd/continuity"
+	"github.com/containerd/continuity/fs"
 	"github.com/moby/sys/mountinfo"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -702,4 +703,21 @@ func lookup(dir string) error {
 
 func isGzipLayerType(mediaType string) bool {
 	return mediaType == specs.MediaTypeImageLayerGzip || mediaType == images.MediaTypeDockerSchema2LayerGzip
+}
+
+func (o *snapshotter) diskUsageWithBlock(ctx context.Context, id string, stype storageType) (snapshots.Usage, error) {
+	usage := snapshots.Usage{}
+	du, err := fs.DiskUsage(ctx, o.upperPath(id))
+	if err != nil {
+		return snapshots.Usage{}, err
+	}
+	usage = snapshots.Usage(du)
+	if stype == storageTypeRemoteBlock || stype == storageTypeLocalBlock {
+		du, err := utils.DiskUsageWithoutMountpoint(ctx, o.blockPath(id))
+		if err != nil {
+			return snapshots.Usage{}, err
+		}
+		usage.Add(snapshots.Usage(du))
+	}
+	return usage, nil
 }

--- a/pkg/utils/cmd.go
+++ b/pkg/utils/cmd.go
@@ -64,7 +64,11 @@ func Seal(ctx context.Context, dir, toDir string, opts ...string) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to seal writable overlaybd: %s", out)
 	}
-	return os.Rename(path.Join(dir, dataFile), path.Join(toDir, sealedFile))
+	if err := os.Rename(path.Join(dir, dataFile), path.Join(toDir, sealedFile)); err != nil {
+		return errors.Wrapf(err, "failed to rename sealed overlaybd file")
+	}
+	os.RemoveAll(path.Join(dir, idxFile))
+	return nil
 }
 
 func Commit(ctx context.Context, dir, toDir string, sealed bool, opts ...string) error {

--- a/pkg/utils/du_unix.go
+++ b/pkg/utils/du_unix.go
@@ -1,0 +1,81 @@
+/*
+   Copyright The Accelerated Container Image Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Based on https://github.com/containerd/continuity/blob/main/fs/du_unix.go
+// Used to calculate the usage of the block dir, excluding the block/mountpoint dir.
+
+package utils
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/containerd/continuity/fs"
+)
+
+const blocksUnitSize = 512
+
+type inode struct {
+	dev, ino uint64
+}
+
+func newInode(stat *syscall.Stat_t) inode {
+	return inode{
+		dev: uint64(stat.Dev), //nolint: unconvert // dev is uint32 on darwin/bsd, uint64 on linux/solaris/freebsd
+		ino: uint64(stat.Ino), //nolint: unconvert // ino is uint32 on bsd, uint64 on darwin/linux/solaris/freebsd
+	}
+}
+
+func DiskUsageWithoutMountpoint(ctx context.Context, roots ...string) (fs.Usage, error) {
+	var (
+		size   int64
+		inodes = map[inode]struct{}{} // expensive!
+	)
+
+	for _, root := range roots {
+		if err := filepath.Walk(root, func(path string, fi os.FileInfo, err error) error {
+			if fi.Name() == "mountpoint" {
+				return filepath.SkipDir
+			}
+			if err != nil {
+				return err
+			}
+
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+			stat := fi.Sys().(*syscall.Stat_t)
+			inoKey := newInode(stat)
+			if _, ok := inodes[inoKey]; !ok {
+				inodes[inoKey] = struct{}{}
+				size += stat.Blocks * blocksUnitSize
+			}
+
+			return nil
+		}); err != nil {
+			return fs.Usage{}, err
+		}
+	}
+
+	return fs.Usage{
+		Inodes: int64(len(inodes)),
+		Size:   size,
+	}, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

- [remove index after seal](https://github.com/containerd/accelerated-container-image/commit/50b3cb1e1f1ba5f966525c86b11d5667c50402b9)
  Remove writable index for overlaybd writable layer after a successful seal to save storage space.
- [fix usage calculation for overlaybd snapshot](https://github.com/containerd/accelerated-container-image/commit/ef2f75ac576aba731944e1621ef784a5162c56da)
  Some space occupancy of overlaybd is not being counted, for example:
  - the lazy downloaded blobs that are not counted for the committed snapshots
  - writable layer space usages are not counted for active snapshots

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [x]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/accelerated-container-image/blob/main/MAINTAINERS. -->
