### PR TITLE
only set vsize on first layer for rw scenarios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,8 +148,8 @@ jobs:
           echo "[ init env ]"
           sudo apt update && sudo apt install -y containerd.io libnl-3-200 libnl-genl-3-200
           sudo modprobe -a target_core_user tcm_loop
-          wget https://github.com/containerd/overlaybd/releases/download/v1.0.2/overlaybd-1.0.2-0ubuntu1.22.04.x86_64.deb &&
-          sudo dpkg -i overlaybd-1.0.2-0ubuntu1.22.04.x86_64.deb
+          wget https://github.com/containerd/overlaybd/releases/download/v1.0.4/overlaybd-1.0.4-0ubuntu1.22.04.x86_64.deb &&
+          sudo dpkg -i overlaybd-1.0.4-0ubuntu1.22.04.x86_64.deb
           sudo systemctl enable /opt/overlaybd/overlaybd-tcmu.service
           sudo systemctl start overlaybd-tcmu
           sudo systemctl status overlaybd-tcmu

--- a/cmd/convertor/builder/overlaybd_builder.go
+++ b/cmd/convertor/builder/overlaybd_builder.go
@@ -99,7 +99,12 @@ func (e *overlaybdBuilderEngine) BuildLayer(ctx context.Context, idx int) error 
 		alreadyConverted = true
 	}
 	if !alreadyConverted {
-		if err := e.create(ctx, layerDir, e.mkfs && (idx == 0)); err != nil {
+		mkfs := e.mkfs && (idx == 0)
+		vsizeGB := 0
+		if idx == 0 {
+			vsizeGB = 64
+		}
+		if err := e.create(ctx, layerDir, mkfs, vsizeGB); err != nil {
 			return err
 		}
 		e.overlaybdConfig.Upper = snapshot.OverlayBDBSConfigUpper{
@@ -294,8 +299,8 @@ func (e *overlaybdBuilderEngine) getLayerDir(idx int) string {
 	return path.Join(e.workDir, fmt.Sprintf("%04d_", idx)+e.manifest.Layers[idx].Digest.String())
 }
 
-func (e *overlaybdBuilderEngine) create(ctx context.Context, dir string, mkfs bool) error {
-	opts := []string{"-s", "64"}
+func (e *overlaybdBuilderEngine) create(ctx context.Context, dir string, mkfs bool, vsizeGB int) error {
+	opts := []string{"-s", fmt.Sprintf("%d", vsizeGB)}
 	if mkfs {
 		opts = append(opts, "--mkfs")
 		logrus.Infof("mkfs for baselayer")

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -17,6 +17,8 @@ This doc includes:
 
 Check whether the `overlaybd-tcmu` is running.
 
+Overlaybd-snapshotter v1.0.1+ requires overlaybd-tcmu v1.0.4+.
+
 For any problems, please checkout [overlaybd](https://github.com/containerd/overlaybd).
 
 ### Proxy overlaybd snapshotter

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -110,6 +110,8 @@ sudo systemctl start overlaybd-snapshotter
 
 Users can compile the latest code to install or download the [release](https://github.com/containerd/overlaybd/releases).
 
+There is no strong dependency between the overlaybd-snapshotter and overlaybd-tcmu versions. However, overlaybd-snapshotter v1.0.1+ requires overlaybd-tcmu v1.0.4+ because there have been adjustments made to the parameters for image conversion.
+
 #### Compile from source
 
 Install dependencies:

--- a/pkg/snapshot/storage.go
+++ b/pkg/snapshot/storage.go
@@ -552,7 +552,11 @@ func (o *snapshotter) constructOverlayBDSpec(ctx context.Context, key string, wr
 			return errors.Errorf("unexpect storage %v of snapshot %v during construct overlaybd spec(writable=%v, parent=%s)", stype, key, writable, info.Parent)
 		}
 		log.G(ctx).Infof("prepare writable layer. (sn: %s)", id)
-		if err := o.prepareWritableOverlaybd(ctx, id); err != nil {
+		vsizeGB := 0
+		if info.Parent == "" {
+			vsizeGB = 64
+		}
+		if err := o.prepareWritableOverlaybd(ctx, id, vsizeGB); err != nil {
 			return err
 		}
 
@@ -648,9 +652,8 @@ func (o *snapshotter) atomicWriteOverlaybdTargetConfig(snID string, configJSON *
 }
 
 // prepareWritableOverlaybd
-func (o *snapshotter) prepareWritableOverlaybd(ctx context.Context, snID string) error {
-	// TODO(fuweid): 256GB can be configurable?
-	args := []string{"64"}
+func (o *snapshotter) prepareWritableOverlaybd(ctx context.Context, snID string, vsizeGB int) error {
+	args := []string{fmt.Sprintf("%d", vsizeGB)}
 	if o.writableLayerType == "sparse" {
 		args = append(args, "-s")
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

only set vsize on first layer for rw scenarios, and inherit the vsize config for the upper layers.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [x]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/accelerated-container-image/blob/main/MAINTAINERS. -->
