### PR TITLE
Fix broken link in QUICKSTART.md

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -85,7 +85,7 @@ The config file is `/etc/overlaybd-snapshotter/config.json`. Please create the f
 | `root` | the root directory to store snapshots |
 | `address` | the socket address used to connect withcontainerd. |
 | `verbose` | log level, `info` or `debug` |
-| `rwMode` | rootfs mode about wether to use native writable layer. See [Native Support for Writable](docs/WRITABLE.md) for detail. |
+| `rwMode` | rootfs mode about wether to use native writable layer. See [Native Support for Writable](./WRITABLE.md) for detail. |
 | `logReportCaller` | enable/disable the calling method |
 | `autoRemoveDev` | enable/disable auto clean-up overlaybd device after container removed |
 | `exporterConfig.enable` | whether or not create a server to show Prometheus metrics |


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes link to `WRITABLE.md` (link broken)

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [x]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [x]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/accelerated-container-image/blob/main/MAINTAINERS. -->
