### PR TITLE
convertor: support setting virtual block device size

### DIFF
--- a/cmd/convertor/builder/builder.go
+++ b/cmd/convertor/builder/builder.go
@@ -50,6 +50,7 @@ type BuilderOptions struct {
 	WorkDir   string
 	OCI       bool
 	Mkfs      bool
+	Vsize     int
 	DB        database.ConversionDatabase
 	Engine    BuilderEngineType
 	CertOption
@@ -101,6 +102,7 @@ func NewOverlayBDBuilder(ctx context.Context, opt BuilderOptions) (Builder, erro
 	engineBase.workDir = opt.WorkDir
 	engineBase.oci = opt.OCI
 	engineBase.mkfs = opt.Mkfs
+	engineBase.vsize = opt.Vsize
 	engineBase.db = opt.DB
 
 	refspec, err := reference.Parse(opt.Ref)

--- a/cmd/convertor/builder/builder_engine.go
+++ b/cmd/convertor/builder/builder_engine.go
@@ -73,6 +73,7 @@ type builderEngineBase struct {
 	workDir      string
 	oci          bool
 	mkfs         bool
+	vsize        int
 	db           database.ConversionDatabase
 	host         string
 	repository   string

--- a/cmd/convertor/builder/overlaybd_builder.go
+++ b/cmd/convertor/builder/overlaybd_builder.go
@@ -102,7 +102,11 @@ func (e *overlaybdBuilderEngine) BuildLayer(ctx context.Context, idx int) error 
 		mkfs := e.mkfs && (idx == 0)
 		vsizeGB := 0
 		if idx == 0 {
-			vsizeGB = 64
+			if mkfs {
+				vsizeGB = e.vsize
+			} else {
+				vsizeGB = 64 // in case that using default baselayer
+			}
 		}
 		if err := e.create(ctx, layerDir, mkfs, vsizeGB); err != nil {
 			return err
@@ -310,7 +314,7 @@ func (e *overlaybdBuilderEngine) create(ctx context.Context, dir string, mkfs bo
 	opts := []string{"-s", fmt.Sprintf("%d", vsizeGB)}
 	if mkfs {
 		opts = append(opts, "--mkfs")
-		logrus.Infof("mkfs for baselayer")
+		logrus.Infof("mkfs for baselayer, vsize: %d GB", vsizeGB)
 	}
 	return utils.Create(ctx, dir, opts...)
 }

--- a/cmd/convertor/builder/turboOCI_builder.go
+++ b/cmd/convertor/builder/turboOCI_builder.go
@@ -233,9 +233,14 @@ func (e *turboOCIBuilderEngine) createIdentifier(idx int) error {
 }
 
 func (e *turboOCIBuilderEngine) create(ctx context.Context, dir string, mkfs bool) error {
-	opts := []string{"-s", "64", "--turboOCI"}
+	vsizeGB := 64
+	if mkfs {
+		vsizeGB = e.vsize
+	}
+	opts := []string{"-s", fmt.Sprintf("%d", vsizeGB), "--turboOCI"}
 	if mkfs {
 		opts = append(opts, "--mkfs")
+		logrus.Infof("mkfs for baselayer, vsize: %d GB", vsizeGB)
 	}
 	return utils.Create(ctx, dir, opts...)
 }

--- a/cmd/convertor/main.go
+++ b/cmd/convertor/main.go
@@ -40,6 +40,7 @@ var (
 	oci       bool
 	mkfs      bool
 	verbose   bool
+	vsize     int
 	fastoci   string
 	turboOCI  string
 	overlaybd string
@@ -87,6 +88,7 @@ var (
 				WorkDir:   dir,
 				OCI:       oci,
 				Mkfs:      mkfs,
+				Vsize:     vsize,
 				CertOption: builder.CertOption{
 					CertDirs:    certDirs,
 					RootCAs:     rootCAs,
@@ -160,8 +162,8 @@ func init() {
 	rootCmd.Flags().StringVarP(&dir, "dir", "d", "tmp_conv", "directory used for temporary data")
 	rootCmd.Flags().BoolVarP(&oci, "oci", "", false, "export image with oci spec")
 	rootCmd.Flags().BoolVarP(&mkfs, "mkfs", "", true, "make ext4 fs in bottom layer")
+	rootCmd.Flags().IntVarP(&vsize, "vsize", "", 64, "virtual block device size (GB)")
 	rootCmd.Flags().StringVar(&fastoci, "fastoci", "", "build 'Overlaybd-Turbo OCIv1' format (old name of turboOCIv1. deprecated)")
-
 	rootCmd.Flags().StringVar(&turboOCI, "turboOCI", "", "build 'Overlaybd-Turbo OCIv1' format")
 	rootCmd.Flags().StringVar(&overlaybd, "overlaybd", "", "build overlaybd format")
 	rootCmd.Flags().StringVar(&dbstr, "db-str", "", "db str for overlaybd conversion")

--- a/cmd/ctr/overlaybd_conv.go
+++ b/cmd/ctr/overlaybd_conv.go
@@ -52,8 +52,13 @@ var convertCommand = cli.Command{
 		},
 		cli.IntFlag{
 			Name:  "bs",
-			Usage: "The size of a compressed data block in KB. Must be a power of two between 4K~64K [4/8/16/32/64])",
+			Usage: "The size of a compressed data block in KB. Must be a power of two between 4K~64K [4/8/16/32/64]",
 			Value: 0,
+		},
+		cli.IntFlag{
+			Name:  "vsize",
+			Usage: "virtual block device size (GB)",
+			Value: 64,
 		},
 	),
 	Action: func(context *cli.Context) error {
@@ -98,6 +103,9 @@ var convertCommand = cli.Command{
 		obdOpts = append(obdOpts, obdconv.WithAlgorithm(algorithm))
 		blockSize := context.Int("bs")
 		obdOpts = append(obdOpts, obdconv.WithBlockSize(blockSize))
+		vsize := context.Int("vsize")
+		fmt.Printf("vsize: %d GB\n", vsize)
+		obdOpts = append(obdOpts, obdconv.WithVsize(vsize))
 
 		resolver, err := commands.GetResolver(ctx, context)
 		if err != nil {

--- a/docs/IMAGE_CONVERTOR.md
+++ b/docs/IMAGE_CONVERTOR.md
@@ -3,7 +3,36 @@
 We provide a ctr command tool to convert OCIv1 images into overlaybd format, which is stored in `bin` after `make` or downloading the release package.
 
 # Basic Usage
+```bash
+# usage
+$ bin/ctr obdconv --help
 
+NAME:
+   ctr obdconv - convert image layer into overlaybd format type
+
+USAGE:
+   ctr obdconv [command options] <src-image> <dst-image>
+
+DESCRIPTION:
+   Export images to an OCI tar[.gz] into zfile format
+
+OPTIONS:
+   --skip-verify, -k       skip SSL certificate validation
+   --plain-http            allow connections using plain HTTP
+   --user value, -u value  user[:password] Registry user and password
+   --refresh value         refresh token for authorization server
+   --hosts-dir value       Custom hosts configuration directory
+   --tlscacert value       path to TLS root CA
+   --tlscert value         path to TLS client certificate
+   --tlskey value          path to TLS client key
+   --http-dump             dump all HTTP request/responses when interacting with container registry
+   --http-trace            enable HTTP tracing for registry interactions
+   --fstype value          filesystem type(required), used to mount block device, support specifying mount options and mkfs options, separate fs type and options by ';', separate mount options by ',', separate mkfs options by ' ' (default: "ext4")
+   --dbstr value           data base config string used for layer deduplication
+   --algorithm value       compress algorithm uses in zfile, [lz4|zstd]
+   --bs value              The size of a compressed data block in KB. Must be a power of two between 4K~64K [4/8/16/32/64] (default: 0)
+   --vsize value           virtual block device size (GB) (default: 64)
+```
 ```bash
 # pull the source image
 sudo ctr i pull registry.hub.docker.com/library/redis:6.2.1

--- a/docs/USERSPACE_CONVERTOR.md
+++ b/docs/USERSPACE_CONVERTOR.md
@@ -43,6 +43,7 @@ Flags:
   -d, --dir string                directory used for temporary data (default "tmp_conv")
       --oci                       export image with oci spec
       --mkfs                      make ext4 fs in bottom layer (default true)
+      --vsize int                 virtual block device size (GB) (default 64)
       --fastoci string            build 'Overlaybd-Turbo OCIv1' format (old name of turboOCIv1. deprecated)
       --turboOCI string           build 'Overlaybd-Turbo OCIv1' format
       --overlaybd string          build overlaybd format
@@ -52,11 +53,15 @@ Flags:
       --root-ca stringArray       root CA certificates
       --client-cert stringArray   client cert certificates, should form in ${cert-file}:${key-file}
       --insecure                  don't verify the server's certificate chain and host name
+      --reserve                   reserve tmp data
+      --no-upload                 don't upload layer and manifest
+      --dump-manifest             dump manifest
   -h, --help                      help for convertor
 
 # examples
 $ bin/convertor -r docker.io/overlaybd/redis -u user:pass -i 6.2.6 -o 6.2.6_obd
 $ bin/convertor -r docker.io/overlaybd/redis -u user:pass -i 6.2.6 --overlaybd 6.2.6_obd --fastoci 6.2.6_foci
+$ bin/convertor -r docker.io/overlaybd/redis -u user:pass -i 6.2.6 -o 6.2.6_obd --vsize 256
 
 ```
 

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -70,6 +70,9 @@ const (
 	// ZFileConfig is the config of ZFile
 	ZFileConfig = "containerd.io/snapshot/overlaybd/zfile-config"
 
+	// OverlayBD virtual block device size
+	OverlayBDVsize = "containerd.io/snapshot/overlaybd/vsize"
+
 	// CRIImageRef is the image-ref from cri
 	CRIImageRef = "containerd.io/snapshot/cri.image-ref"
 

--- a/pkg/snapshot/storage.go
+++ b/pkg/snapshot/storage.go
@@ -551,11 +551,18 @@ func (o *snapshotter) constructOverlayBDSpec(ctx context.Context, key string, wr
 		if !writable {
 			return errors.Errorf("unexpect storage %v of snapshot %v during construct overlaybd spec(writable=%v, parent=%s)", stype, key, writable, info.Parent)
 		}
-		log.G(ctx).Infof("prepare writable layer. (sn: %s)", id)
 		vsizeGB := 0
 		if info.Parent == "" {
-			vsizeGB = 64
+			if vsize, ok := info.Labels[label.OverlayBDVsize]; ok {
+				vsizeGB, err = strconv.Atoi(vsize)
+				if err != nil {
+					vsizeGB = 64
+				}
+			} else {
+				vsizeGB = 64
+			}
 		}
+		log.G(ctx).Infof("prepare writable layer. (sn: %s, vsize: %d GB)", id, vsizeGB)
 		if err := o.prepareWritableOverlaybd(ctx, id, vsizeGB); err != nil {
 			return err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
support setting virtual block device size in convertor in case image size is large than default size (64 GB)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #223, fixes #224 

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [x]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/accelerated-container-image/blob/main/MAINTAINERS. -->
