### PR TITLE
[Feat.] Converting ociv1 layer blob to turboOCI blob locally.

### DIFF
--- a/cmd/convertor/builder/builder_utils.go
+++ b/cmd/convertor/builder/builder_utils.go
@@ -40,7 +40,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"github.com/containerd/accelerated-container-image/pkg/snapshot"
+	t "github.com/containerd/accelerated-container-image/pkg/types"
 )
 
 func fetch(ctx context.Context, fetcher remotes.Fetcher, desc specs.Descriptor, target any) error {
@@ -144,7 +144,7 @@ func downloadLayer(ctx context.Context, fetcher remotes.Fetcher, targetFile stri
 }
 
 // TODO maybe refactor this
-func writeConfig(dir string, configJSON *snapshot.OverlayBDBSConfig) error {
+func writeConfig(dir string, configJSON *t.OverlayBDBSConfig) error {
 	data, err := json.Marshal(configJSON)
 	if err != nil {
 		return err

--- a/cmd/convertor/builder/builder_utils_test.go
+++ b/cmd/convertor/builder/builder_utils_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 
 	testingresources "github.com/containerd/accelerated-container-image/cmd/convertor/testingresources"
-	"github.com/containerd/accelerated-container-image/pkg/snapshot"
+	sn "github.com/containerd/accelerated-container-image/pkg/types"
 	"github.com/containerd/containerd/images"
 	_ "github.com/containerd/containerd/pkg/testutil" // Handle custom root flag
 	"github.com/containerd/containerd/remotes"
@@ -428,9 +428,9 @@ func Test_downloadLayer(t *testing.T) {
 func Test_writeConfig(t *testing.T) {
 	ctx := context.Background()
 	testingresources.RunTestWithTempDir(t, ctx, "writeConfigMinimal", func(t *testing.T, ctx context.Context, workdir string) {
-		configSample := snapshot.OverlayBDBSConfig{
+		configSample := sn.OverlayBDBSConfig{
 			ResultFile: "",
-			Lowers: []snapshot.OverlayBDBSConfigLower{
+			Lowers: []sn.OverlayBDBSConfigLower{
 				{
 					File: overlaybdBaseLayer,
 				},
@@ -438,7 +438,7 @@ func Test_writeConfig(t *testing.T) {
 					File: path.Join(workdir, commitFile),
 				},
 			},
-			Upper: snapshot.OverlayBDBSConfigUpper{
+			Upper: sn.OverlayBDBSConfigUpper{
 				Data:  path.Join(workdir, "writable_data"),
 				Index: path.Join(workdir, "writable_index"),
 			},
@@ -455,7 +455,7 @@ func Test_writeConfig(t *testing.T) {
 		}
 		defer file.Close()
 
-		configRes := snapshot.OverlayBDBSConfig{}
+		configRes := sn.OverlayBDBSConfig{}
 
 		err = json.NewDecoder(file).Decode(&configRes)
 		if err != nil {

--- a/cmd/convertor/builder/overlaybd_builder.go
+++ b/cmd/convertor/builder/overlaybd_builder.go
@@ -26,7 +26,7 @@ import (
 	"path"
 
 	"github.com/containerd/accelerated-container-image/pkg/label"
-	"github.com/containerd/accelerated-container-image/pkg/snapshot"
+	sn "github.com/containerd/accelerated-container-image/pkg/types"
 	"github.com/containerd/accelerated-container-image/pkg/utils"
 	"github.com/containerd/accelerated-container-image/pkg/version"
 	"github.com/containerd/containerd/errdefs"
@@ -50,17 +50,17 @@ type overlaybdConvertResult struct {
 
 type overlaybdBuilderEngine struct {
 	*builderEngineBase
-	overlaybdConfig *snapshot.OverlayBDBSConfig
+	overlaybdConfig *sn.OverlayBDBSConfig
 	overlaybdLayers []overlaybdConvertResult
 }
 
 func NewOverlayBDBuilderEngine(base *builderEngineBase) builderEngine {
-	config := &snapshot.OverlayBDBSConfig{
-		Lowers:     []snapshot.OverlayBDBSConfigLower{},
+	config := &sn.OverlayBDBSConfig{
+		Lowers:     []sn.OverlayBDBSConfigLower{},
 		ResultFile: "",
 	}
 	if !base.mkfs {
-		config.Lowers = append(config.Lowers, snapshot.OverlayBDBSConfigLower{
+		config.Lowers = append(config.Lowers, sn.OverlayBDBSConfigLower{
 			File: overlaybdBaseLayer,
 		})
 		logrus.Infof("using default baselayer")
@@ -111,7 +111,7 @@ func (e *overlaybdBuilderEngine) BuildLayer(ctx context.Context, idx int) error 
 		if err := e.create(ctx, layerDir, mkfs, vsizeGB); err != nil {
 			return err
 		}
-		e.overlaybdConfig.Upper = snapshot.OverlayBDBSConfigUpper{
+		e.overlaybdConfig.Upper = sn.OverlayBDBSConfigUpper{
 			Data:  path.Join(layerDir, "writable_data"),
 			Index: path.Join(layerDir, "writable_index"),
 		}
@@ -130,7 +130,7 @@ func (e *overlaybdBuilderEngine) BuildLayer(ctx context.Context, idx int) error 
 			os.Remove(path.Join(layerDir, "writable_index"))
 		}
 	}
-	e.overlaybdConfig.Lowers = append(e.overlaybdConfig.Lowers, snapshot.OverlayBDBSConfigLower{
+	e.overlaybdConfig.Lowers = append(e.overlaybdConfig.Lowers, sn.OverlayBDBSConfigLower{
 		File: path.Join(layerDir, commitFile),
 	})
 	return nil

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -92,6 +92,9 @@ const (
 
 	// OverlayBDVersion is the version number of overlaybd blob
 	OverlayBDVersion = "containerd.io/snapshot/overlaybd/version"
+
+	// LayerToTurboOCI is used to convert local layer to turboOCI with tar index
+	LayerToTurboOCI = "containerd.io/snapshot/overlaybd/convert2turbo-oci"
 )
 
 // used in filterAnnotationsForSave (https://github.com/moby/buildkit/blob/v0.11/cache/refs.go#L882)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,0 +1,45 @@
+/*
+   Copyright The Accelerated Container Image Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package types
+
+// OverlayBDBSConfig is the config of overlaybd target.
+type OverlayBDBSConfig struct {
+	RepoBlobURL       string                   `json:"repoBlobUrl"`
+	Lowers            []OverlayBDBSConfigLower `json:"lowers"`
+	Upper             OverlayBDBSConfigUpper   `json:"upper"`
+	ResultFile        string                   `json:"resultFile"`
+	AccelerationLayer bool                     `json:"accelerationLayer,omitempty"`
+	RecordTracePath   string                   `json:"recordTracePath,omitempty"`
+}
+
+// OverlayBDBSConfigLower
+type OverlayBDBSConfigLower struct {
+	GzipIndex    string `json:"gzipIndex,omitempty"`
+	File         string `json:"file,omitempty"`
+	Digest       string `json:"digest,omitempty"`
+	TargetFile   string `json:"targetFile,omitempty"`
+	TargetDigest string `json:"targetDigest,omitempty"`
+	Size         int64  `json:"size,omitempty"`
+	Dir          string `json:"dir,omitempty"`
+}
+
+type OverlayBDBSConfigUpper struct {
+	Index     string `json:"index,omitempty"`
+	Data      string `json:"data,omitempty"`
+	Target    string `json:"target,omitempty"`
+	GzipIndex string `json:"gzipIndex,omitempty"`
+}


### PR DESCRIPTION
With [proxyDiffer](https://github.com/containerd/containerd/pull/8399), containerd can decompress tgz layer and convert it to turboOCI blob without unpacking tarball

It is very effective in reducing disk I/O pressure because of replacing unpack multiple files with generating ext4 fsmeta.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/accelerated-container-image/blob/main/MAINTAINERS. -->
