### PR TITLE
Add isPrepareRootfs() method.

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -54,6 +54,7 @@ After download, install the rpm/deb package.
 #### Config
 
 The config file is `/etc/overlaybd-snapshotter/config.json`. Please create the file if not exists.
+**We suggest the root path of snapshotter is a subpath of containerd's root**
 
 ```json
 {
@@ -82,7 +83,7 @@ The config file is `/etc/overlaybd-snapshotter/config.json`. Please create the f
 ```
 | Field | Description |
 | ----- | ----------- |
-| `root` | the root directory to store snapshots |
+| `root` | the root directory to store snapshots. **Suggestion: This path should be a subpath of containerd's root** |
 | `address` | the socket address used to connect withcontainerd. |
 | `verbose` | log level, `info` or `debug` |
 | `rwMode` | rootfs mode about wether to use native writable layer. See [Native Support for Writable](./WRITABLE.md) for detail. |

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/containerd/continuity v0.4.3
 	github.com/containerd/go-cni v1.1.9
 	github.com/containerd/log v0.1.0
-	github.com/data-accelerator/zdfs v0.1.3
+	github.com/data-accelerator/zdfs v0.1.4
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/moby/locker v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cyphar/filepath-securejoin v0.2.3/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
-github.com/data-accelerator/zdfs v0.1.3 h1:fhe2PiV+JvauZ2rBFguEM8/DcFkxtJI+6973E24zTWM=
-github.com/data-accelerator/zdfs v0.1.3/go.mod h1:MnDNsg9RiB+Ey0DzOOQ5sdMSyS8fGKGbcOYI1VULSPI=
+github.com/data-accelerator/zdfs v0.1.4 h1:S7M1lpnVPDANXXXD1ZI6p3ZUempNYVLxUkXbgEUVUkM=
+github.com/data-accelerator/zdfs v0.1.4/go.mod h1:MnDNsg9RiB+Ey0DzOOQ5sdMSyS8fGKGbcOYI1VULSPI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -95,6 +95,8 @@ const (
 
 	// LayerToTurboOCI is used to convert local layer to turboOCI with tar index
 	LayerToTurboOCI = "containerd.io/snapshot/overlaybd/convert2turbo-oci"
+
+	SnapshotType = "containerd.io/snapshot/type"
 )
 
 // used in filterAnnotationsForSave (https://github.com/moby/buildkit/blob/v0.11/cache/refs.go#L882)


### PR DESCRIPTION
    - update zdfs package version to v0.1.4
    - update snapshotter config doc
    - add isPrepareRootfs() method to check if current prepared layer
      is a rootfs layer or image layer.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [x]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/accelerated-container-image/blob/main/MAINTAINERS. -->
