### PR TITLE
Add 'tenant' config to make snapshotter manage tcmu devices easier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ force:
 # build a binary from cmd
 bin/%: cmd/% force
 	@echo "$@"
-	@GOOS=linux CGO_ENABLED=0 go build -o $@ ./$<
+	@GOOS=linux CGO_ENABLED=0 go build -ldflags "-X 'main.commitID=$$(git rev-parse --short HEAD)'" -o $@ ./$<
 
 install: ## install binaries from bin
 	@mkdir -p $(SN_DESTDIR)

--- a/pkg/snapshot/overlay.go
+++ b/pkg/snapshot/overlay.go
@@ -91,6 +91,7 @@ type BootConfig struct {
 	WritableLayerType string                 `json:"writableLayerType"` // append or sparse
 	MirrorRegistry    []Registry             `json:"mirrorRegistry"`
 	DefaultFsType     string                 `json:"defaultFsType"`
+	Tenant            int                    `json:"tenant"` // do not set this if only a single snapshotter service in the host
 }
 
 func DefaultBootConfig() *BootConfig {
@@ -107,6 +108,7 @@ func DefaultBootConfig() *BootConfig {
 		MirrorRegistry:    nil,
 		WritableLayerType: "append",
 		DefaultFsType:     "ext4",
+		Tenant:            -1,
 	}
 }
 
@@ -173,8 +175,8 @@ type snapshotter struct {
 	writableLayerType string
 	mirrorRegistry    []Registry
 	defaultFsType     string
-
-	locker *locker.Locker
+	tenant            int
+	locker            *locker.Locker
 }
 
 // NewSnapshotter returns a Snapshotter which uses block device based on overlayFS.
@@ -226,6 +228,7 @@ func NewSnapshotter(bootConfig *BootConfig, opts ...Opt) (snapshots.Snapshotter,
 		mirrorRegistry:    bootConfig.MirrorRegistry,
 		defaultFsType:     bootConfig.DefaultFsType,
 		locker:            locker.New(),
+		tenant:            bootConfig.Tenant,
 	}, nil
 }
 


### PR DESCRIPTION
There will be some tcmu device id conflicts if more than one snap- shotter process running on a single host. Add 'tenant' config to distinguish their own tcmu ID

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/accelerated-container-image/blob/main/MAINTAINERS. -->
