### PR TITLE
Enable TurboOCI format for EROFS

### DIFF
--- a/cmd/convertor/builder/builder.go
+++ b/cmd/convertor/builder/builder.go
@@ -54,6 +54,7 @@ type BuilderOptions struct {
 	PlainHTTP bool
 	WorkDir   string
 	OCI       bool
+	FsType    string
 	Mkfs      bool
 	Vsize     int
 	DB        database.ConversionDatabase
@@ -234,6 +235,7 @@ func (b *graphBuilder) buildOne(ctx context.Context, src v1.Descriptor, tag bool
 	}
 	engineBase.workDir = workdir
 	engineBase.oci = b.OCI
+	engineBase.fstype = b.FsType
 	engineBase.mkfs = b.Mkfs
 	engineBase.vsize = b.Vsize
 	engineBase.db = b.DB

--- a/cmd/convertor/builder/builder_engine.go
+++ b/cmd/convertor/builder/builder_engine.go
@@ -85,6 +85,7 @@ type builderEngineBase struct {
 	config       specs.Image
 	workDir      string
 	oci          bool
+	fstype       string
 	mkfs         bool
 	vsize        int
 	db           database.ConversionDatabase

--- a/cmd/convertor/main.go
+++ b/cmd/convertor/main.go
@@ -39,6 +39,7 @@ var (
 	tagOutput        string
 	dir              string
 	oci              bool
+	fsType           string
 	mkfs             bool
 	verbose          bool
 	vsize            int
@@ -93,6 +94,7 @@ Version: ` + commitID,
 				PlainHTTP: plain,
 				WorkDir:   dir,
 				OCI:       oci,
+				FsType:    fsType,
 				Mkfs:      mkfs,
 				Vsize:     vsize,
 				CertOption: builder.CertOption{
@@ -159,6 +161,7 @@ func init() {
 	rootCmd.Flags().StringVarP(&tagOutput, "output-tag", "o", "", "tag for image converting to")
 	rootCmd.Flags().StringVarP(&dir, "dir", "d", "tmp_conv", "directory used for temporary data")
 	rootCmd.Flags().BoolVarP(&oci, "oci", "", false, "export image with oci spec")
+	rootCmd.Flags().StringVar(&fsType, "fstype", "ext4", "filesystem type of converted image.")
 	rootCmd.Flags().BoolVarP(&mkfs, "mkfs", "", true, "make ext4 fs in bottom layer")
 	rootCmd.Flags().IntVarP(&vsize, "vsize", "", 64, "virtual block device size (GB)")
 	rootCmd.Flags().StringVar(&fastoci, "fastoci", "", "build 'Overlaybd-Turbo OCIv1' format (old name of turboOCIv1. deprecated)")

--- a/pkg/snapshot/storage.go
+++ b/pkg/snapshot/storage.go
@@ -502,10 +502,11 @@ func (o *snapshotter) constructOverlayBDSpec(ctx context.Context, key string, wr
 
 		configJSON.RepoBlobURL = blobPrefixURL
 		if isTurboOCI, dataDgst, compType := o.checkTurboOCI(info.Labels); isTurboOCI {
+			fsmeta, _ := o.turboOCIFsMeta(id)
 			lower := sn.OverlayBDBSConfigLower{
 				Dir: o.upperPath(id),
 				// keep this to support ondemand turboOCI loading.
-				File:         o.turboOCIFsMeta(id),
+				File:         fsmeta,
 				TargetDigest: dataDgst,
 			}
 			if isGzipLayerType(compType) {

--- a/pkg/utils/cmd.go
+++ b/pkg/utils/cmd.go
@@ -160,7 +160,7 @@ func ApplyTurboOCI(ctx context.Context, dir, gzipMetaFile string, opts ...string
 		path.Join(dir, "config.json"),
 		"--gz_index_path", path.Join(dir, gzipMetaFile)}, opts...)
 	log.G(ctx).Debugf("%s %s", obdBinApply, strings.Join(args, " "))
-	out, err := exec.CommandContext(ctx, obdBinApply, args...).CombinedOutput()
+	out, err := exec.CommandContext(ctx, obdBinTurboOCIApply, args...).CombinedOutput()
 	if err != nil {
 		return errors.Wrapf(err, "failed to overlaybd-apply[turboOCI]: %s", out)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable TurboOCI format for EROFS filesystem

To build a EROFS TurboOCI image,
$ bin/convertor --fstype erofs -r \<repo\> -i \<input-tag\> --turboOCI \<turboOCI-tag\>

If `--fstype` is not given, ext4 is used by default.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/accelerated-container-image/blob/main/MAINTAINERS. -->
