### PR TITLE
CI: prevent remote code execution through github action

### DIFF
--- a/.github/workflows/ci-unit-test.yml
+++ b/.github/workflows/ci-unit-test.yml
@@ -1,0 +1,36 @@
+name: Unit Test
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - 'main'
+
+jobs:
+  unit-test:
+    name: Unit Test
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: src/github.com/containerd/accelerated-container-image
+          fetch-depth: 100
+
+      - name: install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.0'
+
+      - name: set env
+        shell: bash
+        run: |
+          echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+
+      - name: unit test
+        working-directory: src/github.com/containerd/accelerated-container-image
+        run: |
+          sudo GO_TESTFLAGS=-v make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,34 +17,6 @@ on:
       - labeled
 
 jobs:
-  unit-test:
-    name: Unit Test
-    runs-on: ubuntu-22.04
-    timeout-minutes: 10
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          path: src/github.com/containerd/accelerated-container-image
-          fetch-depth: 100
-
-      - name: install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.22.0'
-
-      - name: set env
-        shell: bash
-        run: |
-          echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
-          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
-
-      - name: unit test
-        working-directory: src/github.com/containerd/accelerated-container-image
-        run: |
-          sudo GO_TESTFLAGS=-v make test
-
   lowercase-repo:
     name: Lowercase Repo
     runs-on: ubuntu-22.04


### PR DESCRIPTION
**What this PR does / why we need it**:
There is a vulnerability to checkout the PR within `pull_request_target` GitHub Actions workflow. See also [Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/accelerated-container-image/blob/main/MAINTAINERS. -->
