### PR TITLE
[Feat.] Support 'prioritize files' as a new prefetch mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Accelerated Container Image is a __non-core__ sub-project of containerd.
 
 * See the [PERFORMANCE](docs/PERFORMANCE.md) test about the acceleration.
 
+* Enable 'record-trace' function can achieve higher performance for the entrypoint that needs to read amount of data at container startup. See [ENABLE_TRACE](docs/trace-prefetch.md).
+
 * See how to convert OCI image into overlaybd with specified file system at [MULTI_FS_SUPPORT](docs/MULTI_FS_SUPPORT.md).
 
 * See how to use layer deduplication for image conversion at [IMAGE_CONVERTOR](docs/IMAGE_CONVERTOR.md).

--- a/pkg/snapshot/overlay.go
+++ b/pkg/snapshot/overlay.go
@@ -208,6 +208,13 @@ func NewSnapshotter(bootConfig *BootConfig, opts ...Opt) (snapshots.Snapshotter,
 		return nil, err
 	}
 
+	root, err := filepath.EvalSymlinks(bootConfig.Root)
+	if err != nil {
+		log.L.Errorf("invalid root: %s. (%s)", bootConfig.Root, err.Error())
+		return nil, err
+	}
+	log.L.Infof("new snapshotter: root = %s", root)
+
 	metacopyOption := ""
 	if _, err := os.Stat("/sys/module/overlay/parameters/metacopy"); err == nil {
 		metacopyOption = "metacopy=on"
@@ -224,7 +231,7 @@ func NewSnapshotter(bootConfig *BootConfig, opts ...Opt) (snapshots.Snapshotter,
 	}
 
 	return &snapshotter{
-		root:              bootConfig.Root,
+		root:              root,
 		rwMode:            bootConfig.RwMode,
 		ms:                ms,
 		indexOff:          indexOff,


### PR DESCRIPTION
**What this PR does / why we need it**:

The current trace-record mode is difficult to use in non-production environments. This PR adds a new prefetch mode called 'prioritize files', people can set a filelist to download target files in advance.

See details in 'docs/trace-prefetch.md'

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [x]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/accelerated-container-image/blob/main/MAINTAINERS. -->
