### PR TITLE
check if snapshot holds mountpoint before remove

### DIFF
--- a/internal/log/helper.go
+++ b/internal/log/helper.go
@@ -1,0 +1,30 @@
+/*
+   Copyright The Accelerated Container Image Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package log
+
+import (
+	"context"
+	"fmt"
+
+	clog "github.com/containerd/log"
+)
+
+func TracedErrorf(ctx context.Context, format string, args ...any) error {
+	err := fmt.Errorf(format, args...)
+	clog.G(ctx).Error(err)
+	return err
+}

--- a/pkg/snapshot/overlay.go
+++ b/pkg/snapshot/overlay.go
@@ -29,6 +29,7 @@ import (
 	"github.com/containerd/accelerated-container-image/pkg/label"
 	"github.com/containerd/accelerated-container-image/pkg/snapshot/diskquota"
 
+	mylog "github.com/containerd/accelerated-container-image/internal/log"
 	"github.com/containerd/accelerated-container-image/pkg/metrics"
 	"github.com/data-accelerator/zdfs"
 	"github.com/sirupsen/logrus"
@@ -944,7 +945,7 @@ func (o *snapshotter) Remove(ctx context.Context, key string) (err error) {
 		if err == nil {
 			err = o.unmountAndDetachBlockDevice(ctx, id, key)
 			if err != nil {
-				return errors.Wrapf(err, "failed to destroy target device for snapshot %s", key)
+				return mylog.TracedErrorf(ctx, "failed to destroy target device for snapshot %s: %w", key, err)
 			}
 		}
 	}
@@ -961,10 +962,18 @@ func (o *snapshotter) Remove(ctx context.Context, key string) (err error) {
 			if st, err := o.identifySnapshotStorageType(ctx, s.ParentIDs[0], info); err == nil && st != storageTypeNormal {
 				err = o.unmountAndDetachBlockDevice(ctx, s.ParentIDs[0], "")
 				if err != nil {
-					return errors.Wrapf(err, "failed to destroy target device for snapshot %s", key)
+					return mylog.TracedErrorf(ctx, "failed to destroy target device for snapshot %s: %w", key, err)
 				}
 			}
 		}
+	}
+
+	// Just in case, check if snapshot contains mountpoint
+	mounted, err := o.isMounted(ctx, o.overlaybdMountpoint(id))
+	if err != nil {
+		return mylog.TracedErrorf(ctx, "failed to check mountpoint: %w", err)
+	} else if mounted {
+		return mylog.TracedErrorf(ctx, "try to remove snapshot %s which still have mountpoint", id)
 	}
 
 	_, _, err = storage.Remove(ctx, key)


### PR DESCRIPTION
**What this PR does / why we need it**:
Enhance snapshotter.Remove to avoid delete snapshots which hold a mountpoint.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/accelerated-container-image/blob/main/MAINTAINERS. -->
