### PR TITLE
Support digest for input image in convertor

### DIFF
--- a/.github/workflows/ci-userspace-convertor.yml
+++ b/.github/workflows/ci-userspace-convertor.yml
@@ -50,11 +50,12 @@ jobs:
         shell: bash
         run: |
           bash new_registry.sh
-          bash prepare_image.sh registry.hub.docker.com/overlaybd/centos:centos7.9.2009 localhost:5000/centos:centos7.9.2009 && \
-          bash prepare_image.sh registry.hub.docker.com/overlaybd/ubuntu:22.04          localhost:5000/ubuntu:22.04 && \
-          bash prepare_image.sh registry.hub.docker.com/overlaybd/redis:7.2.3           localhost:5000/redis:7.2.3 && \
-          bash prepare_image.sh registry.hub.docker.com/overlaybd/wordpress:6.4.2       localhost:5000/wordpress:6.4.2 && \
-          bash prepare_image.sh registry.hub.docker.com/overlaybd/nginx:1.25.3          localhost:5000/nginx:1.25.3
+          bash prepare_image.sh registry.hub.docker.com/overlaybd/centos:centos7.9.2009                                                                   localhost:5000/centos:centos7.9.2009 && \
+          bash prepare_image.sh registry.hub.docker.com/overlaybd/ubuntu:22.04                                                                            localhost:5000/ubuntu:22.04 && \
+          bash prepare_image.sh registry.hub.docker.com/overlaybd/redis:7.2.3                                                                             localhost:5000/redis:7.2.3 && \
+          bash prepare_image.sh registry.hub.docker.com/overlaybd/redis@sha256:309f99718ff2424f4ae5ebf0e46f7f0ce03058bf47d9061d1d66e4af53b70ffc           localhost:5000/redis@sha256:309f99718ff2424f4ae5ebf0e46f7f0ce03058bf47d9061d1d66e4af53b70ffc && \
+          bash prepare_image.sh registry.hub.docker.com/overlaybd/wordpress:6.4.2                                                                         localhost:5000/wordpress:6.4.2 && \
+          bash prepare_image.sh registry.hub.docker.com/overlaybd/nginx:1.25.3                                                                            localhost:5000/nginx:1.25.3
 
       - name: CI - uconv reproduce
         working-directory: ci/uconv_reproduce
@@ -69,6 +70,14 @@ jobs:
           /opt/overlaybd/snapshotter/convertor -r localhost:5000/redis -i 7.2.3 --overlaybd 7.2.3_overlaybd --turboOCI 7.2.3_turbo
           bash run_container.sh localhost:5000/redis:7.2.3_overlaybd
           bash run_container.sh localhost:5000/redis:7.2.3_turbo
+
+      - name: CI - uconv E2E with digest input
+        working-directory: ci/scripts
+        shell: bash
+        run: |
+          /opt/overlaybd/snapshotter/convertor -r localhost:5000/redis -g sha256:309f99718ff2424f4ae5ebf0e46f7f0ce03058bf47d9061d1d66e4af53b70ffc --overlaybd 309f99718ff2424f4ae5ebf0e46f7f0ce03058bf47d9061d1d66e4af53b70ffc_overlaybd --turboOCI sha256:309f99718ff2424f4ae5ebf0e46f7f0ce03058bf47d9061d1d66e4af53b70ffc_turbo
+          bash run_container.sh localhost:5000/redis:309f99718ff2424f4ae5ebf0e46f7f0ce03058bf47d9061d1d66e4af53b70ffc_overlaybd
+          bash run_container.sh localhost:5000/redis:309f99718ff2424f4ae5ebf0e46f7f0ce03058bf47d9061d1d66e4af53b70ffc_turbo
 
       - name: install Go
         uses: actions/setup-go@v5

--- a/docs/USERSPACE_CONVERTOR.md
+++ b/docs/USERSPACE_CONVERTOR.md
@@ -38,7 +38,8 @@ Flags:
   -u, --username string           user[:password] Registry user and password
       --plain                     connections using plain HTTP
       --verbose                   show debug log
-  -i, --input-tag string          tag for image converting from (required)
+  -i, --input-tag string          tag for image converting from (required when input-digest is not set)
+  -g, --input-digest string       digest for image converting from (required when input-tag is not set)
   -o, --output-tag string         tag for image converting to
   -d, --dir string                directory used for temporary data (default "tmp_conv")
       --oci                       export image with oci spec
@@ -64,6 +65,7 @@ Flags:
 
 # examples
 $ bin/convertor -r docker.io/overlaybd/redis -u user:pass -i 6.2.6 -o 6.2.6_obd
+$ bin/convertor -r docker.io/overlaybd/redis -u user:pass -g sha256:309f99718ff2424f4ae5ebf0e46f7f0ce03058bf47d9061d1d66e4af53b70ffc -o 309f99718ff2424f4ae5ebf0e46f7f0ce03058bf47d9061d1d66e4af53b70ffc_obd
 $ bin/convertor -r docker.io/overlaybd/redis -u user:pass -i 6.2.6 --overlaybd 6.2.6_obd --fastoci 6.2.6_foci
 $ bin/convertor -r docker.io/overlaybd/redis -u user:pass -i 6.2.6 -o 6.2.6_obd --vsize 256
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The userspace convertor requires an `--input-tag` to identify the image to convert ([USERSPACE_CONVERTOR.md](https://github.com/containerd/accelerated-container-image/blob/main/docs/USERSPACE_CONVERTOR.md)). 
```
-i, --input-tag string          tag for image converting from (required)
```
This is sometimes inconvenient because:
* A tag can be volatile
* Sometimes the client has access to the digest but not the tags on the image to convert


This PR supports a parameter to specify the digest of the image to convert, as an enhancement. 
```
-g, input-digest             digest for image converting from (required when input-tag is not set)
```
With this change, the command accepts either a tag (`--input-tag`) or a digest (`--input-digest`) to specify the image to convert. 

Example usage with the digest parameter:
```
bin/convertor -r docker.io/overlaybd/redis -u user:pass -g sha256:309f99718ff2424f4ae5ebf0e46f7f0ce03058bf47d9061d1d66e4af53b70ffc -o 309f99718ff2424f4ae5ebf0e46f7f0ce03058bf47d9061d1d66e4af53b70ffc_obd
```

**Manual test**

I built the convertor locally, and ran it to convert an image with digest to verify it works:
```
sudo bin/convertor --mkfs --repository my.registry.com/repo --username <user>:<password>--input-digest sha256:ea1b8ca870974180c0f369eda3dbb529e06303ff8b519a237573002d7ed85bee --overlaybd 0.1-overlaybd

INFO[0000] building [Overlaybd - Native]  image...
INFO[0000] building tmp_conv/1--ea1b8ca870974180c0f369eda3dbb529e06303ff8b519a237573002d7ed85bee ...
INFO[0000] fetching manifest sha256:ea1b8ca870974180c0f369eda3dbb529e06303ff8b519a237573002d7ed85bee with type application/vnd.docker.distribution.manifest.v2+json
INFO[0002] downloaded layer 0
INFO[0002] mkfs for baselayer, vsize: 64 GB
INFO[0003] layer 0 committed, uuid: bce45ce6-13d3-4bff-6a34-04a4c2d56a5f, parent uuid:
INFO[0003] layer 0 converted
INFO[0007] layer 0 uploaded
INFO[0008] config uploaded
INFO[0009] manifest uploaded, sha256:2446e61a1ea59a980b96e6e1e32b639ac4be4a05b64cb45ee2c8b4bd7f9c038e
INFO[0009] convert finished
INFO[0009] converted to "my.registry.com/repo:0.1-overlaybd", digest: "sha256:2446e61a1ea59a980b96e6e1e32b639ac4be4a05b64cb45ee2c8b4bd7f9c038e"
INFO[0009] overlaybd build finished
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #284

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [x]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/accelerated-container-image/blob/main/MAINTAINERS. -->
