### PR TITLE
[EROFS] Add a check for erofs

### DIFF
--- a/pkg/snapshot/overlay.go
+++ b/pkg/snapshot/overlay.go
@@ -17,6 +17,7 @@
 package snapshot
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -1379,10 +1380,18 @@ func (o *snapshotter) blockPath(id string) string {
 	return filepath.Join(o.root, "snapshots", id, "block")
 }
 
+func IsErofsSupported() bool {
+	fs, err := os.ReadFile("/proc/filesystems")
+	if err != nil || !bytes.Contains(fs, []byte("\terofs\n")) {
+		return false
+	}
+	return true
+}
+
 func (o *snapshotter) turboOCIFsMeta(id string) (string, string) {
 	// TODO: make the priority order (multi-meta exists) configurable later if needed
 	erofsmeta := filepath.Join(o.root, "snapshots", id, "fs", "erofs.fs.meta")
-	if _, err := os.Stat(erofsmeta); err == nil {
+	if _, err := os.Stat(erofsmeta); err == nil && IsErofsSupported() {
 		return erofsmeta, "erofs"
 	}
 	return filepath.Join(o.root, "snapshots", id, "fs", "ext4.fs.meta"), "ext4"


### PR DESCRIPTION
Add an additional check to verify whether the host machine truly supports the EROFS file system, and only mount it as the EROFS file system if it is supported.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/accelerated-container-image/blob/main/MAINTAINERS. -->
