### PR TITLE
fix error MediaType when get dup manifest from db

### DIFF
--- a/cmd/convertor/builder/overlaybd_builder.go
+++ b/cmd/convertor/builder/overlaybd_builder.go
@@ -282,7 +282,7 @@ func (e *overlaybdBuilderEngine) CheckForConvertedManifest(ctx context.Context) 
 	entry := e.db.GetManifestEntryForRepo(ctx, e.host, e.repository, e.mediaTypeManifest(), e.inputDesc.Digest)
 	if entry != nil && entry.ConvertedDigest != "" {
 		convertedDesc := specs.Descriptor{
-			MediaType: e.mediaTypeImageLayer(),
+			MediaType: e.mediaTypeManifest(),
 			Digest:    entry.ConvertedDigest,
 			Size:      entry.DataSize,
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
When re-converting overlaybd image, the mediaType of the manifest read from the database should be "application/vnd.docker.distribution.manifest.v2+json", but it is incorrectly set to "application/vnd.docker.image.rootfs.diff.tar". 

note: This issue only occurs in the case of converting multi-architecture images, as only during this conversion is a new index manifest uploaded. In the case of converting single-architecture images, the manifest is not uploaded, and the process ends directly.


**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
no
- [ ]  Does this change require a documentation update?
no
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
no
- [ ]  Do all new files have an appropriate license header?
no

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/accelerated-container-image/blob/main/MAINTAINERS. -->
