### PR TITLE
support priority order for turbo fs type

### DIFF
--- a/cmd/overlaybd-snapshotter/main.go
+++ b/cmd/overlaybd-snapshotter/main.go
@@ -76,6 +76,20 @@ func main() {
 		go metrics.Init()
 		logrus.Infof("set Prometheus metrics exporter in http://localhost:%d%s", metrics.Config.Port, metrics.Config.UriPrefix)
 	}
+	contain := func(fsType string) bool {
+		for _, fst := range pconfig.TurboFsType {
+			if fst == fsType {
+				return true
+			}
+		}
+		return false
+	}
+	if !contain("ext4") {
+		pconfig.TurboFsType = append(pconfig.TurboFsType, "ext4")
+	}
+	if !contain("erofs") {
+		pconfig.TurboFsType = append(pconfig.TurboFsType, "erofs")
+	}
 
 	if err := setLogLevel(pconfig.LogLevel); err != nil {
 		logrus.Errorf("failed to set log level: %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
support support priority order for turbo fs type, by default in order of `ext4`, `erofs`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/accelerated-container-image/blob/main/MAINTAINERS. -->
