### PR TITLE
Fix userspace convertor output tagging on manifest dedup

### DIFF
--- a/cmd/convertor/builder/builder_engine.go
+++ b/cmd/convertor/builder/builder_engine.go
@@ -89,6 +89,9 @@ type Deduplicateable interface {
 	// store manifest digest -> converted manifest to avoid re-conversion
 	CheckForConvertedManifest(ctx context.Context) (specs.Descriptor, error)
 
+	// tag a converted manifest -> converted manifest to avoid re-conversion
+	TagPreviouslyConvertedManifest(ctx context.Context, desc specs.Descriptor) error
+
 	// store manifest digest -> converted manifest to avoid re-conversion
 	StoreConvertedManifestDetails(ctx context.Context) error
 }

--- a/cmd/convertor/builder/builder_test.go
+++ b/cmd/convertor/builder/builder_test.go
@@ -139,5 +139,9 @@ func (e *mockFuzzBuilderEngine) DownloadConvertedLayer(ctx context.Context, idx 
 	return nil
 }
 
+func (e *mockFuzzBuilderEngine) TagPreviouslyConvertedManifest(ctx context.Context, desc specs.Descriptor) error {
+	return nil
+}
+
 func (e *mockFuzzBuilderEngine) Cleanup() {
 }

--- a/cmd/convertor/builder/builder_utils.go
+++ b/cmd/convertor/builder/builder_utils.go
@@ -234,6 +234,21 @@ func uploadBytes(ctx context.Context, pusher remotes.Pusher, desc specs.Descript
 	return content.Copy(ctx, cw, bytes.NewReader(data), desc.Size, desc.Digest)
 }
 
+func tagPreviouslyConvertedManifest(ctx context.Context, pusher remotes.Pusher, fetcher remotes.Fetcher, desc specs.Descriptor) error {
+	manifest := specs.Manifest{}
+	if err := fetch(ctx, fetcher, desc, &manifest); err != nil {
+		return fmt.Errorf("failed to fetch converted manifest: %w", err)
+	}
+	cbuf, err := json.Marshal(manifest)
+	if err != nil {
+		return err
+	}
+	if err := uploadBytes(ctx, pusher, desc, cbuf); err != nil {
+		return fmt.Errorf("failed to tag converted manifest: %w", err)
+	}
+	return nil
+}
+
 func buildArchiveFromFiles(ctx context.Context, target string, compress compression.Compression, files ...string) error {
 	archive, err := os.Create(target)
 	if err != nil {

--- a/cmd/convertor/builder/overlaybd_builder.go
+++ b/cmd/convertor/builder/overlaybd_builder.go
@@ -337,6 +337,11 @@ func (e *overlaybdBuilderEngine) CheckForConvertedManifest(ctx context.Context) 
 	return specs.Descriptor{}, errdefs.ErrNotFound
 }
 
+// If a converted manifest has been found we still need to tag it to match the expected output tag.
+func (e *overlaybdBuilderEngine) TagPreviouslyConvertedManifest(ctx context.Context, desc specs.Descriptor) error {
+	return tagPreviouslyConvertedManifest(ctx, e.pusher, e.fetcher, desc)
+}
+
 // mountImage is responsible for mounting a specific manifest from a source repository, this includes
 // mounting all layers + config and then pushing the manifest.
 func (e *overlaybdBuilderEngine) mountImage(ctx context.Context, manifest specs.Manifest, desc specs.Descriptor, mountRepository string) error {

--- a/cmd/convertor/builder/turboOCI_builder.go
+++ b/cmd/convertor/builder/turboOCI_builder.go
@@ -213,6 +213,11 @@ func (e *turboOCIBuilderEngine) UploadImage(ctx context.Context) (specs.Descript
 	return e.uploadManifestAndConfig(ctx)
 }
 
+// If a converted manifest has been found we still need to tag it to match the expected output tag.
+func (e *turboOCIBuilderEngine) TagPreviouslyConvertedManifest(ctx context.Context, desc specs.Descriptor) error {
+	return tagPreviouslyConvertedManifest(ctx, e.pusher, e.fetcher, desc)
+}
+
 // Layer deduplication in FastOCI is not currently supported due to conversion not
 // being reproducible at the moment which can lead to occasional bugs.
 

--- a/cmd/convertor/resources/samples/mysql-db-manifest-cache-sample-workload.sh
+++ b/cmd/convertor/resources/samples/mysql-db-manifest-cache-sample-workload.sh
@@ -11,11 +11,20 @@ mysqldbpassword=$8 # mysql password
 oras login $registry -u $username -p $password
 oras cp $sourceImage $registry/$repository:$tag
 # Try one conversion
-./bin/convertor --repository $registry/$repository -u $username:$password --input-tag $tag --oci --overlaybd $tag-obd-cache --db-str "$mysqldbuser:mysqldbpassword@tcp(127.0.0.1:3306)/conversioncache" --db-type mysql
+./bin/convertor --repository $registry/$repository -u $username:$password --input-tag $tag --oci --overlaybd $tag-obd-cache --db-str "$mysqldbuser:$mysqldbpassword@tcp(127.0.0.1:3306)/conversioncache" --db-type mysql
 
 # Retry, result manifest should be cached
-./bin/convertor --repository $registry/$repository -u $username:$password --input-tag $tag --oci --overlaybd $tag-obd-cache-2 --db-str "$mysqldbuser:mysqldbpassword@tcp(127.0.0.1:3306)/conversioncache" --db-type mysql
+./bin/convertor --repository $registry/$repository -u $username:$password --input-tag $tag --oci --overlaybd $tag-obd-cache-2 --db-str "$mysqldbuser:$mysqldbpassword@tcp(127.0.0.1:3306)/conversioncache" --db-type mysql
 
 # Retry, cross repo mount
 oras cp $sourceImage $registry/$repository-2:$tag
-./bin/convertor --repository $registry/$repository -u $username:$password --input-tag $tag --oci --overlaybd $tag-obd-cache-2 --db-str "$mysqldbuser:mysqldbpassword@tcp(127.0.0.1:3306)/conversioncache" --db-type mysql
+./bin/convertor --repository $registry/$repository-2 -u $username:$password --input-tag $tag --oci --overlaybd $tag-obd-cache-3 --db-str "$mysqldbuser:$mysqldbpassword@tcp(127.0.0.1:3306)/conversioncache" --db-type mysql
+
+# Expected output in the registry:
+# <Repository>
+#    -- <Tag>
+#    -- <Tag>-obd-cache
+#    -- <Tag>-obd-cache-2
+# <Repository>-2
+#    -- <Tag>
+#    -- <Tag>-obd-cache-3

--- a/cmd/convertor/resources/samples/run-userspace-convertor-ubuntu.Dockerfile
+++ b/cmd/convertor/resources/samples/run-userspace-convertor-ubuntu.Dockerfile
@@ -11,7 +11,7 @@ RUN apt update && \
     apt install -y libcurl4-openssl-dev libext2fs-dev libaio-dev mysql-server
 
 # --- OVERLAYBD TOOLS ---
-FROM base As overlaybd-build
+FROM base AS overlaybd-build
 RUN apt update && \
     apt install -y libgflags-dev libssl-dev libnl-3-dev libnl-genl-3-dev libzstd-dev && \
     apt install -y zlib1g-dev binutils make git wget sudo tar gcc cmake build-essential g++ && \
@@ -19,9 +19,9 @@ RUN apt update && \
     apt install -y pkg-config
 
 # Download and install Golang version 1.21
-RUN wget https://go.dev/dl/go1.20.12.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf go1.20.12.linux-amd64.tar.gz && \
-    rm go1.20.12.linux-amd64.tar.gz
+RUN wget https://go.dev/dl/go1.23.2.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf go1.23.2.linux-amd64.tar.gz && \
+    rm go1.23.2.linux-amd64.tar.gz
 
 # Set environment variables
 ENV PATH="/usr/local/go/bin:${PATH}"
@@ -56,8 +56,18 @@ COPY --from=overlaybd-build /opt/overlaybd/baselayers /opt/overlaybd/baselayers
 COPY --from=overlaybd-build /etc/overlaybd/overlaybd.json /etc/overlaybd/overlaybd.json
 COPY --from=convert-build /home/limiteduser/accelerated-container-image/bin/convertor ./bin/convertor
 
+# EXTRAS
 # Useful resources
 COPY cmd/convertor/resources/samples/mysql.conf ./mysql.conf
 COPY cmd/convertor/resources/samples/mysql-db-setup.sh ./mysql-db-setup.sh
 COPY cmd/convertor/resources/samples/mysql-db-manifest-cache-sample-workload.sh ./mysql-db-manifest-cache-sample-workload.sh
+
+RUN apt update && apt install -y wget
+# Add Oras CLI
+RUN wget "https://github.com/oras-project/oras/releases/download/v1.2.0/oras_1.2.0_linux_amd64.tar.gz" && \
+    mkdir -p oras-install/ && \
+    tar -zxf oras_1.2.0_*.tar.gz -C oras-install/ && \
+    mv oras-install/oras /usr/local/bin/ && \
+    rm -rf oras_1.2.0_*.tar.gz oras-install/
+
 CMD ["./bin/convertor"]


### PR DESCRIPTION
This PR fixes deduplicated manifests not accounting for possible adjustments to output tag. It also includes unit tests as well as updates to the validation scripts that help test such scenarios in a local environment. I was able to validate the change with my own registry as well.  Thanks to @fourierrr for their earlier pr and opening the issue.

**What this PR does / why we need it**: This is a bugfix to address the scenario where a user wants to convert a previously converted image but expects a different output tag than the original. Without this change the user's converted image may end up being untagged or at least not referenced by the expected tag.

Fixes #310 

**Please check the following list**:
- [X]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/accelerated-container-image/blob/main/MAINTAINERS. -->
