### PR TITLE
[bugfix] convertor: turbo error when vsize != 64

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -51,15 +51,14 @@ jobs:
           echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
           echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
-      # TODO(fuweid): remove the env GO111MODULE=off in new version of go
       - name: install dependencies
         shell: bash
         env:
-          GO111MODULE: off
+          GO111MODULE: on
         run: |
           echo "::group:: install dependencies"
-          go get -u -v github.com/vbatts/git-validation
-          go get -u -v github.com/kunalkushwaha/ltag
+          go install -v github.com/vbatts/git-validation@latest
+          go install -v github.com/kunalkushwaha/ltag@latest
           echo "::endgroup::"
 
       - name: DCO checker

--- a/.github/workflows/ci-userspace-convertor.yml
+++ b/.github/workflows/ci-userspace-convertor.yml
@@ -70,6 +70,9 @@ jobs:
           /opt/overlaybd/snapshotter/convertor -r localhost:5000/redis -i 7.2.3 --overlaybd 7.2.3_overlaybd --turboOCI 7.2.3_turbo
           bash run_container.sh localhost:5000/redis:7.2.3_overlaybd
           bash run_container.sh localhost:5000/redis:7.2.3_turbo
+          /opt/overlaybd/snapshotter/convertor -r localhost:5000/redis -i 7.2.3 --overlaybd 7.2.3_overlaybd_256 --turboOCI 7.2.3_turbo_256 --vsize 256
+          bash run_container.sh localhost:5000/redis:7.2.3_overlaybd_256
+          bash run_container.sh localhost:5000/redis:7.2.3_turbo_256
 
       - name: CI - uconv E2E with digest input
         working-directory: ci/scripts

--- a/ci/scripts/run_container.sh
+++ b/ci/scripts/run_container.sh
@@ -2,6 +2,8 @@
 #
 # rpull and run on-demand
 
+set -x
+
 image=$1
 container_name=${2:-test}
 
@@ -11,6 +13,7 @@ exit_code=0
 if ! ctr run -d --net-host --snapshotter=overlaybd "${image}" "${container_name}"; then
   exit_code=1
 fi
+lsblk
 if ! ctr t ls | grep "${container_name}"; then
   exit_code=1
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:
All overlaybd image layers should be in the same virtual size, but there was something wrong with userspace convertor (turbo only), which resulting in layers with inconsistent virtual size. We can easily reproduce the error with following command:
```
/opt/overlaybd/snapshotter/convertor -r localhost:5000/redis -i 7.2.3 --turboOCI 7.2.3_turbo_256 --vsize 256
# converted image '7.2.3_turbo_256' can't work
```
This bug occurs when converting TurboOCI and `--vsize` is greater than 64.

Otherwise, the project-check workflow is broken due to newer go version. It has been fixed in this PR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/accelerated-container-image/blob/main/MAINTAINERS. -->
