### PR TITLE
EROFS TurboOCI enhancement

### DIFF
--- a/pkg/snapshot/overlay.go
+++ b/pkg/snapshot/overlay.go
@@ -21,8 +21,10 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 	"unsafe"
@@ -606,9 +608,9 @@ func (o *snapshotter) createMountPoint(ctx context.Context, kind snapshots.Kind,
 				if isTurboOCI, _, _ := o.checkTurboOCI(obdInfo.Labels); isTurboOCI {
 					_, fsType = o.turboOCIFsMeta(obdID)
 				} else {
+					log.G(ctx).Warnf("cannot get fs type from label, %v, using %s", obdInfo.Labels, fsType)
 					fsType = o.defaultFsType
 				}
-				log.G(ctx).Warnf("cannot get fs type from label, %v, using %s", obdInfo.Labels, fsType)
 			}
 			log.G(ctx).Debugf("attachAndMountBlockDevice (obdID: %s, writeType: %s, fsType %s, targetPath: %s)",
 				obdID, writeType, fsType, o.overlaybdTargetPath(obdID))
@@ -1471,16 +1473,31 @@ func (o *snapshotter) blockPath(id string) string {
 	return filepath.Join(o.root, "snapshots", id, "block")
 }
 
+var erofsSupported = false
+var erofsSupportedOnce sync.Once
+
+// If EROFS fsmeta exists and is prioritized, check and modprobe erofs
 func IsErofsSupported() bool {
-	fs, err := os.ReadFile("/proc/filesystems")
-	if err != nil || !bytes.Contains(fs, []byte("\terofs\n")) {
-		return false
-	}
-	return true
+	erofsSupportedOnce.Do(func() {
+		fs, err := os.ReadFile("/proc/filesystems")
+		if err != nil || !bytes.Contains(fs, []byte("\terofs\n")) {
+			// Try to `modprobe erofs` again
+			cmd := exec.Command("modprobe", "erofs")
+			_, err = cmd.CombinedOutput()
+			if err != nil {
+				return
+			}
+			fs, err = os.ReadFile("/proc/filesystems")
+			if err != nil || !bytes.Contains(fs, []byte("\terofs\n")) {
+				return
+			}
+		}
+		erofsSupported = true
+	})
+	return erofsSupported
 }
 
 func (o *snapshotter) turboOCIFsMeta(id string) (string, string) {
-	// TODO: make the priority order (multi-meta exists) configurable later if needed
 	for _, fsType := range o.turboFsType {
 		fsmeta := filepath.Join(o.root, "snapshots", id, "fs", fsType+".fs.meta")
 		if _, err := os.Stat(fsmeta); err == nil {

--- a/pkg/snapshot/overlay.go
+++ b/pkg/snapshot/overlay.go
@@ -121,8 +121,8 @@ func DefaultBootConfig() *BootConfig {
 		RootfsQuota:       "",
 		Tenant:            -1,
 		TurboFsType: []string{
-			"ext4",
 			"erofs",
+			"ext4",
 		},
 	}
 }

--- a/pkg/snapshot/storage.go
+++ b/pkg/snapshot/storage.go
@@ -542,7 +542,15 @@ func (o *snapshotter) constructOverlayBDSpec(ctx context.Context, key string, wr
 
 		configJSON.RepoBlobURL = blobPrefixURL
 		if isTurboOCI, dataDgst, compType := o.checkTurboOCI(info.Labels); isTurboOCI {
-			fsmeta, _ := o.turboOCIFsMeta(id)
+			var fsmeta string
+
+			// If parent layers exist, follow the meta choice from the bottom layer
+			if info.Parent != "" {
+				_, fsmeta = filepath.Split(configJSON.Lowers[0].File)
+				fsmeta = filepath.Join(o.root, "snapshots", id, "fs", fsmeta)
+			} else {
+				fsmeta, _ = o.turboOCIFsMeta(id)
+			}
 			lower := sn.OverlayBDBSConfigLower{
 				Dir: o.upperPath(id),
 				// keep this to support ondemand turboOCI loading.


### PR DESCRIPTION
**What this PR does / why we need it**:
 1. Some robustness enhancement (like using the bottom layer fsmeta rather than a random fstype, which keeps in sync with internal versions);
 2. Fallback to EXT4 if .TurboOCI_ext4 exists;
 3. Prefer to use EROFS if related metadata (`erofs.fs.meta`) is valid for TurboOCI, since:
     - First, it has no impact if "ext4.fs.meta" exists only;
     - Second, it has no impact if the kernel doesn't support EROFS;
     - Third, only TurboOCI images built with "--fstype erofs" or
            where multiple fsmeta exists take effect;
     - Fourth, ".TurboOCI_ext4" is used for emergency fallback.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/accelerated-container-image/blob/main/MAINTAINERS. -->
