### PR TITLE
ci: fix project checks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           echo "::group:: install dependencies"
           go install -v github.com/vbatts/git-validation@latest
-          go install -v github.com/kunalkushwaha/ltag@latest
+          go install -v github.com/containerd/ltag@latest
           echo "::endgroup::"
 
       - name: DCO checker


### PR DESCRIPTION
The github.com/kunalkushwaha/ltag project moved to the containerd org; currently it's failing;

```
  github.com/vbatts/git-validation
  go: downloading github.com/kunalkushwaha/ltag v0.3.0
  go: github.com/kunalkushwaha/ltag@latest: version constraints conflict:
  	github.com/kunalkushwaha/ltag@v0.3.0: parsing go.mod:
  	module declares its path as: github.com/containerd/ltag
  	        but was required as: github.com/kunalkushwaha/ltag
  Error: Process completed with exit code 1.
```


**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/accelerated-container-image/blob/main/MAINTAINERS. -->
