### PR TITLE
chore: upgrade golang to 1.26

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.23]
+        go-version: [1.26]
 
     steps:
       - uses: actions/setup-go@v6
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.7
+          version: v2.9
           skip-cache: true
           args: --timeout=5m
 

--- a/.github/workflows/ci-build-image.yml
+++ b/.github/workflows/ci-build-image.yml
@@ -13,7 +13,7 @@ on:
         type: string
 
 env:
-  GO_VERSION: "1.23"
+  GO_VERSION: "1.26"
   OBD_VERSION: "1.0.12"
 
 jobs:

--- a/.github/workflows/ci-unit-test.yml
+++ b/.github/workflows/ci-unit-test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.23'
+          go-version: '1.26'
 
       - name: set env
         shell: bash

--- a/.github/workflows/ci-userspace-convertor.yml
+++ b/.github/workflows/ci-userspace-convertor.yml
@@ -85,7 +85,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.23'
+          go-version: '1.26'
 
       - name: set env
         shell: bash

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.23'
+        go-version: '1.26'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
       - "v*"
 
 env:
-  GO_VERSION: "1.23"
+  GO_VERSION: "1.26"
 
 jobs:
   build:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,7 @@ Add to /etc/containerd/config.toml:
 
 ## Dependencies
 
-- Go >= 1.23.x
+- Go >= 1.26.x
 - containerd >= 2.0.x
 - runc >= 1.0
 - overlaybd backstore (https://github.com/containerd/overlaybd)

--- a/ci/e2e/go.mod
+++ b/ci/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/accelerated-container-image/ci/e2e
 
-go 1.23.0
+go 1.26.0
 
 require (
 	github.com/containerd/containerd/v2 v2.0.7

--- a/cmd/convertor/resources/samples/run-userspace-convertor-ubuntu.Dockerfile
+++ b/cmd/convertor/resources/samples/run-userspace-convertor-ubuntu.Dockerfile
@@ -19,9 +19,9 @@ RUN apt update && \
     apt install -y pkg-config
 
 # Download and install Golang version 1.21
-RUN wget https://go.dev/dl/go1.23.2.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf go1.23.2.linux-amd64.tar.gz && \
-    rm go1.23.2.linux-amd64.tar.gz
+RUN wget https://go.dev/dl/go1.26.0.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf go1.26.0.linux-amd64.tar.gz && \
+    rm go1.26.0.linux-amd64.tar.gz
 
 # Set environment variables
 ENV PATH="/usr/local/go/bin:${PATH}"

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -11,7 +11,7 @@ This doc includes:
 
 ## Requirements
 
-* Install Go >= 1.23.x
+* Install Go >= 1.26.x
 * Install runc >= 1.0
 * Install containerd >= 2.0.x
   * See [Downloads at containerd.io](https://containerd.io/downloads/).

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -37,7 +37,7 @@ Users can compile the latest code to install or download the [release](https://g
 #### Compile from source
 
 Install dependencies:
-- golang 1.23+
+- golang 1.26+
 
 Run the following commands to build:
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/accelerated-container-image
 
-go 1.23.0
+go 1.26.0
 
 require (
 	github.com/containerd/containerd/api v1.8.0

--- a/pkg/snapshot/storage.go
+++ b/pkg/snapshot/storage.go
@@ -447,7 +447,7 @@ func (o *snapshotter) attachAndMountBlockDevice(ctx context.Context, snID string
 	if err := lookup(o.overlaybdMountpoint(snID)); err == nil {
 		return nil
 	} else {
-		log.G(ctx).Infof(err.Error())
+		log.G(ctx).Info(err.Error())
 	}
 	device, err := AttachDevice(ctx,
 		NewAttachDeviceParams(


### PR DESCRIPTION
**What this PR does / why we need it**:

Update golang to 1.26 as 1.23 support has ended

**Please check the following list**:
- [X]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/accelerated-container-image/blob/main/MAINTAINERS. -->
