### PR TITLE
go.mod: don't enforce latest go version

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,6 +30,8 @@ jobs:
           - 1.26
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: install Go
         uses: actions/setup-go@v6
         with:
@@ -56,6 +58,7 @@ jobs:
         with:
           path: src/github.com/containerd/accelerated-container-image
           fetch-depth: 100
+          persist-credentials: false
 
       - name: set env
         shell: bash

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,25 +5,31 @@ on:
       - main
   pull_request:
 
+env:
+  GOTOOLCHAIN: local
+
 jobs:
   #
   # Linter checker
   #
   linters:
-    name: Linters
+    name: Linters (${{ matrix.go-version || 'minimum' }})
     runs-on: ubuntu-22.04
     timeout-minutes: 10
 
     strategy:
       matrix:
-        go-version: [1.26]
-
+        go-version:
+          - "" # empty; fall back on go-version-file (use go.mod); see https://github.com/actions/setup-go/issues/450#issuecomment-3620402646
+          - 1.26
     steps:
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@v6
+      - name: install Go
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
-
-      - uses: actions/checkout@v6
+          go-version-file: "go.mod" # used when go-version is not specified.
+          check-latest: true
       - uses: golangci/golangci-lint-action@v9
         with:
           version: v2.9

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,6 +5,12 @@ on:
       - main
   pull_request:
 
+# Default to 'contents: read', which grants actions to read commits.
+#
+# see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+permissions:
+  contents: read
+
 env:
   GOTOOLCHAIN: local
 

--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -9,6 +9,12 @@ on:
         required: true
         type: string
 
+# Default to 'contents: read', which grants actions to read commits.
+#
+# see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+permissions:
+  contents: read
+
 jobs:
   run-ci-basic:
     name: Run CI | Basic

--- a/.github/workflows/ci-build-image.yml
+++ b/.github/workflows/ci-build-image.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/ci-build-image.yml
+++ b/.github/workflows/ci-build-image.yml
@@ -12,6 +12,12 @@ on:
         required: true
         type: string
 
+# Default to 'contents: read', which grants actions to read commits.
+#
+# see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+permissions:
+  contents: read
+
 env:
   GO_VERSION: "1.26"
   OBD_VERSION: "1.0.12"

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -12,6 +12,12 @@ on:
         required: true
         type: string
 
+# Default to 'contents: read', which grants actions to read commits.
+#
+# see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ci-unit-test.yml
+++ b/.github/workflows/ci-unit-test.yml
@@ -7,12 +7,19 @@ on:
     branches:
       - 'main'
 
+env:
+  GOTOOLCHAIN: local
+
 jobs:
   unit-test:
-    name: Unit Test
+    name: Unit Test (${{ matrix.go-version || 'minimum' }})
     runs-on: ubuntu-22.04
     timeout-minutes: 10
-
+    strategy:
+      matrix:
+        go-version:
+          - "" # empty; fall back on go-version-file (use go.mod); see https://github.com/actions/setup-go/issues/450#issuecomment-3620402646
+          - 1.26
     steps:
       - uses: actions/checkout@v6
         with:
@@ -21,7 +28,9 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: ${{ matrix.go-version }}
+          go-version-file: "go.mod" # used when go-version is not specified.
+          check-latest: true
 
       - name: unit test
         run: |

--- a/.github/workflows/ci-unit-test.yml
+++ b/.github/workflows/ci-unit-test.yml
@@ -7,6 +7,12 @@ on:
     branches:
       - 'main'
 
+# Default to 'contents: read', which grants actions to read commits.
+#
+# see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+permissions:
+  contents: read
+
 env:
   GOTOOLCHAIN: local
 

--- a/.github/workflows/ci-unit-test.yml
+++ b/.github/workflows/ci-unit-test.yml
@@ -34,4 +34,4 @@ jobs:
 
       - name: unit test
         run: |
-          sudo GO_TESTFLAGS=-v make test
+          GO_TESTFLAGS='-v -exec sudo' make test

--- a/.github/workflows/ci-unit-test.yml
+++ b/.github/workflows/ci-unit-test.yml
@@ -16,7 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          path: src/github.com/containerd/accelerated-container-image
           fetch-depth: 100
 
       - name: install Go
@@ -24,13 +23,6 @@ jobs:
         with:
           go-version: '1.26'
 
-      - name: set env
-        shell: bash
-        run: |
-          echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
-          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
-
       - name: unit test
-        working-directory: src/github.com/containerd/accelerated-container-image
         run: |
           sudo GO_TESTFLAGS=-v make test

--- a/.github/workflows/ci-unit-test.yml
+++ b/.github/workflows/ci-unit-test.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 100
+          persist-credentials: false
 
       - name: install Go
         uses: actions/setup-go@v6

--- a/.github/workflows/ci-userspace-convertor.yml
+++ b/.github/workflows/ci-userspace-convertor.yml
@@ -12,11 +12,19 @@ on:
         required: true
         type: string
 
+env:
+  GOTOOLCHAIN: local
+
 jobs:
   run-ci-userspace-convertor:
-    name: Run CI | Userspace Convertor
+    name: Run CI | Userspace Convertor (${{ matrix.go-version || 'minimum' }})
     runs-on: ubuntu-22.04
     timeout-minutes: 10
+    strategy:
+      matrix:
+        go-version:
+          - "" # empty; fall back on go-version-file (use go.mod); see https://github.com/actions/setup-go/issues/450#issuecomment-3620402646
+          - 1.26
     container:
       image: ghcr.io/${{ inputs.github-repository }}/overlaybd-ci-images:${{ inputs.image-tag }}
       credentials:
@@ -85,7 +93,9 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: ${{ matrix.go-version }}
+          go-version-file: "go.mod" # used when go-version is not specified.
+          check-latest: true
 
       - name: set env
         shell: bash

--- a/.github/workflows/ci-userspace-convertor.yml
+++ b/.github/workflows/ci-userspace-convertor.yml
@@ -12,6 +12,12 @@ on:
         required: true
         type: string
 
+# Default to 'contents: read', which grants actions to read commits.
+#
+# see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+permissions:
+  contents: read
+
 env:
   GOTOOLCHAIN: local
 

--- a/.github/workflows/ci-userspace-convertor.yml
+++ b/.github/workflows/ci-userspace-convertor.yml
@@ -51,6 +51,7 @@ jobs:
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Start OverlayBD
         working-directory: /app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,12 @@ on:
     branches:
       - main
 
+# Default to 'contents: read', which grants actions to read commits.
+#
+# see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+permissions:
+  contents: read
+
 jobs:
   lowercase-repo:
     name: Lowercase Repo

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+env:
+  GOTOOLCHAIN: local
+
 jobs:
   CodeQL-Build:
 
@@ -25,6 +28,7 @@ jobs:
     - uses: actions/setup-go@v6
       with:
         go-version: '1.26'
+        check-latest: true
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,10 +13,6 @@ env:
 
 jobs:
   CodeQL-Build:
-
-    strategy:
-      fail-fast: false
-
     runs-on: ubuntu-22.04
 
     timeout-minutes: 30

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,12 +8,22 @@ on:
     branches:
       - main
 
+# Default to 'contents: read', which grants actions to read commits.
+#
+# see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+permissions:
+  contents: read
+
 env:
   GOTOOLCHAIN: local
 
 jobs:
   CodeQL-Build:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
 
     timeout-minutes: 30
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - uses: actions/setup-go@v6
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,12 @@ on:
     tags:
       - "v*"
 
+# Default to 'contents: read', which grants actions to read commits.
+#
+# see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+permissions:
+  contents: read
+
 env:
   GO_VERSION: "1.26"
 
@@ -68,6 +74,8 @@ jobs:
     name: Development Release
     if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs: [build]
     steps:
       - name: Download builds and release notes
@@ -92,6 +100,8 @@ jobs:
     name: Tagged Release
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs: [build]
     steps:
       - name: Download builds and release notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         fetch-depth: 100
+        persist-credentials: false
     - name: Setup buildx instance
       uses: docker/setup-buildx-action@v2
       with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,11 @@
 module github.com/containerd/accelerated-container-image
 
-go 1.26.0
+// The go directive declares the minimum Go version required for this module.
+//
+// DO NOT change this version unless support for older Go versions is dropped
+// or the module requires newer Go features. To update the version used for CI
+// and releases, update "go-version" and "GO_VERSION" in "/.github/workflows".
+go 1.25
 
 require (
 	github.com/containerd/containerd/api v1.8.0


### PR DESCRIPTION
- relates to https://github.com/containerd/accelerated-container-image/pull/344

Commit e9d822973438af917dc95a929262075d2c221e01 updated the version of go to use for this module, but also updated the go directive in go.mod, preventing users of this module to use lower versions.

For modules used as library, Go generally recommends supporting at least the current stable and "oldstable" (stable -1) releases.

This patch:

- downgrades the go directive in go.mod to go1.25
- updates github actions workflows to test both the specified version (1.26) and the version specified in go.mod (minimal version).

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/containerd/accelerated-container-image/blob/main/MAINTAINERS. -->
