### PR TITLE
ci: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -38,7 +38,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
           go-version-file: "go.mod" # used when go-version is not specified.
           check-latest: true
-      - uses: golangci/golangci-lint-action@v9
+      - uses: golangci/golangci-lint-action@63c23d5020da8f97005b6de340504130bdbe42c7 # v9
         with:
           version: v2.9
           skip-cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         fetch-depth: 100
         persist-credentials: false
     - name: Setup buildx instance
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
       with:
         use: true
     - name: Build
@@ -88,7 +88,7 @@ jobs:
         shell: bash
         run: ls -lR releases/
       - name: Create Release
-        uses: "marvinpinto/action-automatic-releases@latest"
+        uses: "marvinpinto/action-automatic-releases@d68defdd11f9dcc7f52f35c1b7c236ee7513bcc1" # latest
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "latest"
@@ -114,7 +114,7 @@ jobs:
         shell: bash
         run: ls -lR releases/
       - name: Create Release
-        uses: "marvinpinto/action-automatic-releases@latest"
+        uses: "marvinpinto/action-automatic-releases@d68defdd11f9dcc7f52f35c1b7c236ee7513bcc1" # latest
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           prerelease: false


### PR DESCRIPTION
Two of the third-party actions in CI are referenced by floating refs, and `marvinpinto/action-automatic-releases@latest` is the riskiest kind: `latest` resolves to whatever the maintainer last tagged, with zero review on our side, and it runs in the release workflow where the token has write access. golangci-lint-action is pinned to the `v9` major tag, which can also be moved.

Floating refs are the exact vector behind CVE-2025-30066 (tj-actions/changed-files), where an attacker rewrote existing tags to point at credential-stealing commits. Pinning to a verified commit SHA means the runner only ever executes the code we looked at.

This change pins:

- golangci/golangci-lint-action (v9) in check.yml
- docker/setup-buildx-action (v2) and both uses of marvinpinto/action-automatic-releases (latest) in release.yml

The tag name stays in a trailing comment for readability and future bumps. I deliberately left ci-build-image.yml alone because it is a reusable workflow (on: workflow_call), and skipped the GitHub-owned actions/* entries. Pins like these are what the OpenSSF Scorecard Pinned-Dependencies check looks for.