### PR TITLE
ci: add Dependabot config to auto-update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+# Keep dependencies up to date automatically.
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates
+version: 2
+updates:
+  # Go modules
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gomod"
+    directory: "/ci/e2e"
+    schedule:
+      interval: "weekly"
+
+  # GitHub Actions used by CI/release workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # Docker base images used for builds
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/ci/build_image"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml` to enable automated **weekly** dependency updates via Dependabot for:

- **Go modules** — `/` and `/ci/e2e` (`go.mod`).
- **GitHub Actions** (`/`) — keeps CI/release workflow actions current (incl. security patches).
- **Docker** — base images in `/` and `/ci/build_image`.

## Why

Dependencies in this repo are not currently tracked for updates, so security fixes in Go modules, actions, and base images can go unnoticed. Dependabot will open PRs as updates become available for maintainers to review and merge.

Note: schedule is `weekly` to balance freshness vs. PR noise — happy to switch to `monthly` or add grouping if preferred.

Signed-off-by included (DCO).