### PR TITLE
fix(convertor): drop BuildKit attestation manifests instead of panicking

### DIFF
--- a/cmd/convertor/builder/builder.go
+++ b/cmd/convertor/builder/builder.go
@@ -91,6 +91,20 @@ type graphBuilder struct {
 	id        atomic.Int32
 }
 
+const (
+	attestationManifestAnnotation = "vnd.docker.reference.type"
+	attestationManifestType       = "attestation-manifest"
+)
+
+// isAttestationManifest reports whether desc is a BuildKit attestation manifest
+// (provenance/SBOM). Detection uses only the explicit
+// vnd.docker.reference.type=attestation-manifest annotation: the accompanying
+// unknown/unknown platform is a BuildKit convention shared by other artifacts,
+// so it is not a reliable identifier on its own.
+func isAttestationManifest(desc v1.Descriptor) bool {
+	return desc.Annotations[attestationManifestAnnotation] == attestationManifestType
+}
+
 func (b *graphBuilder) Build(ctx context.Context) error {
 	fetcher, err := b.Resolver.Fetcher(ctx, b.Ref)
 	if err != nil {
@@ -150,6 +164,17 @@ func (b *graphBuilder) process(ctx context.Context, src v1.Descriptor, tag bool)
 		for _i, _m := range index.Manifests {
 			i := _i
 			m := _m
+			if isAttestationManifest(m) {
+				// BuildKit attestation manifests (provenance/SBOM) carry no
+				// rootfs layers and reference a source platform manifest by
+				// digest (vnd.docker.reference.digest). That digest changes on
+				// conversion, so the attestation cannot be re-associated and
+				// converting its zero-layer manifest panics. Drop it from the
+				// converted index (with a warning) rather than emitting a stale
+				// reference.
+				log.G(ctx).Warnf("skipping attestation manifest %s: cannot be re-associated after conversion", m.Digest)
+				continue
+			}
 			wg.Add(1)
 			b.group.Go(func() error {
 				defer wg.Done()
@@ -165,6 +190,16 @@ func (b *graphBuilder) process(ctx context.Context, src v1.Descriptor, tag bool)
 		if ctx.Err() != nil {
 			return v1.Descriptor{}, ctx.Err()
 		}
+
+		// Drop attestation manifests from the converted index: their
+		// source-digest references no longer point at an image in the index.
+		filtered := index.Manifests[:0]
+		for _, m := range index.Manifests {
+			if !isAttestationManifest(m) {
+				filtered = append(filtered, m)
+			}
+		}
+		index.Manifests = filtered
 
 		// upload index
 		if b.Referrer {

--- a/cmd/convertor/builder/builder_attestation_test.go
+++ b/cmd/convertor/builder/builder_attestation_test.go
@@ -1,0 +1,78 @@
+/*
+   Copyright The Accelerated Container Image Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package builder
+
+import (
+	"testing"
+
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func TestIsAttestationManifest(t *testing.T) {
+	tests := []struct {
+		name string
+		desc v1.Descriptor
+		want bool
+	}{
+		{
+			name: "attestation annotation",
+			desc: v1.Descriptor{
+				Annotations: map[string]string{
+					"vnd.docker.reference.type": "attestation-manifest",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "attestation annotation with unknown platform",
+			desc: v1.Descriptor{
+				Annotations: map[string]string{
+					"vnd.docker.reference.type": "attestation-manifest",
+				},
+				Platform: &v1.Platform{OS: "unknown", Architecture: "unknown"},
+			},
+			want: true,
+		},
+		{
+			name: "unknown platform without attestation annotation is not an attestation",
+			desc: v1.Descriptor{
+				Platform: &v1.Platform{OS: "unknown", Architecture: "unknown"},
+			},
+			want: false,
+		},
+		{
+			name: "normal image manifest",
+			desc: v1.Descriptor{
+				Platform: &v1.Platform{OS: "linux", Architecture: "amd64"},
+			},
+			want: false,
+		},
+		{
+			name: "descriptor without attestation metadata",
+			desc: v1.Descriptor{},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isAttestationManifest(tt.desc); got != tt.want {
+				t.Errorf("isAttestationManifest() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The userspace convertor panics on OCI indexes that contain a BuildKit attestation manifest (images built with `docker buildx --provenance=true` / `--sbom=true`). This detects attestation manifests by their explicit annotation and drops them from the converted index (with a warning) instead of feeding a zero-layer manifest into the rootfs builder engine.

## Motivation

Provenance is enabled by default with the Buildx `docker-container` driver since v0.10, so ordinary multi-platform images now carry an attestation manifest in their index. Converting such an image crashes the tool with `panic: index out of range [0] with length 0`, which makes overlaybd conversion unusable for the common default Buildx output until the attestation entry is manually stripped. Closes the crash so these images convert cleanly.

---

**What this PR does / why we need it**:

The userspace convertor panics (`panic: index out of range [0] with length 0` in `NewOverlayBDBuilderEngine()` / `NewTurboOCIBuilderEngine()`) when an OCI index contains a BuildKit attestation manifest — for example an image built with `docker buildx --provenance=true`, `--sbom=true`, or `--attest`. Provenance is enabled by default with the Buildx `docker-container` driver since v0.10, so this is hit by ordinary multi-platform images.

An attestation manifest uses the image-manifest media type, so `graphBuilder.process()` dispatched it to `buildOne()`, which builds a rootfs-layer engine over a manifest that has zero layers — hence the index-out-of-range panic. BuildKit marks these entries with an `unknown/unknown` platform and the annotation `vnd.docker.reference.type: attestation-manifest`.

This change:

- adds `isAttestationManifest()`, which detects an attestation entry by BuildKit's explicit `vnd.docker.reference.type: attestation-manifest` annotation (the accompanying `unknown/unknown` platform is a shared BuildKit convention, so it is not used as an identifier on its own to avoid dropping unrelated artifacts);
- in the index-traversal loop, skips attestation manifests (with a warning) instead of converting them, and drops them from the rebuilt index.

Attestation manifests reference their subject platform manifest by digest (`vnd.docker.reference.digest`). Since conversion changes that manifest's digest, the attestation cannot be re-associated with the converted image, and carrying the descriptor through unchanged would leave a dangling reference in the output index. Dropping it (the "omit the descriptor with a warning" option noted in the issue) keeps the index self-consistent and stops the crash. Preserving provenance/SBOM across conversion — which requires rewriting and re-pushing the attestation's reference, and the cross-repository blob-copy question raised in the issue — is left as a follow-up.

**Which issue(s) this PR fixes**:

Fixes #378

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test? — added a unit test for `isAttestationManifest` covering the annotation, the annotation together with an `unknown/unknown` platform, an `unknown/unknown` platform without the annotation (not an attestation), a normal platform manifest, and an empty descriptor.
- [ ]  Does this change require a documentation update? — no.
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version? — no; it only changes behavior for inputs that previously panicked.
- [x]  Do all new files have an appropriate license header? — the new test file carries the standard Apache-2.0 header.

<!-- Verified locally: go build ./cmd/convertor/..., go vet, gofmt, and go test -run TestIsAttestationManifest all pass. The pre-existing Test_fetchManifest/Fetch_manifest_List failure reproduces on main and is unrelated to this change. -->
